### PR TITLE
give structs a name so they can be forward declared

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -36,7 +36,7 @@ extern "C" {
 #define TINYEXR_PIXELTYPE_HALF (1)
 #define TINYEXR_PIXELTYPE_FLOAT (2)
 
-typedef struct {
+typedef struct _EXRImage {
   int num_channels;
   const char **channel_names;
   unsigned char **images; // image[channels][pixels]
@@ -45,7 +45,7 @@ typedef struct {
   int height;
 } EXRImage;
 
-typedef struct {
+typedef struct _DeepImage {
   int num_channels;
   const char **channel_names;
   float ***image;     // image[channels][scanlines][samples]


### PR DESCRIPTION
This allows you to forward declare one of these structs from a header, like:

```cpp
typedef struct _EXRImage EXRImage;
```

Otherwise, clang gives the error message:

```
tinyexr.h:46:3: error: typedef redefinition with different types ('struct EXRImage' vs 'struct _EXRImage')
} EXRImage;
```

An alternative would be to declass the EXRImage as a C++ struct, but it looks like you're sticking with straight C and using `struct EXRImage ...` would go against this.