### PR TITLE
Add <cstddef> #include to tinyexr.h.

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -27,6 +27,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __TINYEXR_H__
 #define __TINYEXR_H__
 
+#include <cstddef>   // for size_t
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Otherwise compiles will fail due to the use of size_t in tinyexr.h.
(Unless tinyexr.h is included after some other #include that included
something that defined size_t…)