### PR TITLE
Fixed warnings.

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -4377,7 +4377,7 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN(f, m, s) freopen(f, m, s)
 #define MZ_DELETE_FILE remove
-#elif defined(__GNUC__) && _LARGEFILE64_SOURCE
+#elif defined(__GNUC__) && defined(_LARGEFILE64_SOURCE) && _LARGEFILE64_SOURCE
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
 - Fixed bunch of miniz `warning: enumeral and non-enumeral type in conditional expression`

 - Fixed warning `tinyexr.h:8551:6: warning: unused parameter ‘outSize’` (but it might be actually bug, you should check).

 - Disabled MSVC warnings:

```
	#pragma warning(disable : 4244) // 'initializing': conversion from '__int64' to
                                	// 'int', possible loss of data
	#pragma warning(disable : 4267) // 'argument': conversion from '__int64' to 'int',
	                                // possible loss of data
	#pragma warning(disable : 4996) // 'strdup': The POSIX name for this item is
	                                // deprecated. Instead, use the ISO C and C++
	                                // conformant name: _strdup.
```