### PR TITLE
Fix deep image loading

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -11670,6 +11670,7 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
     if (0 == size) {
       return TINYEXR_ERROR_INVALID_DATA;
     } else if (marker[0] == '\0') {
+      marker++;
       size--;
       break;
     }
@@ -11859,11 +11860,13 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
     // decode sample data.
     {
       unsigned long dstLen = static_cast<unsigned long>(unpackedSampleDataSize);
-      tinyexr::DecompressZip(
-          reinterpret_cast<unsigned char *>(&sample_data.at(0)), &dstLen,
-          data_ptr + 28 + packedOffsetTableSize,
-          static_cast<unsigned long>(packedSampleDataSize));
-      assert(dstLen == static_cast<unsigned long>(unpackedSampleDataSize));
+      if (dstLen) {
+        tinyexr::DecompressZip(
+            reinterpret_cast<unsigned char *>(&sample_data.at(0)), &dstLen,
+            data_ptr + 28 + packedOffsetTableSize,
+            static_cast<unsigned long>(packedSampleDataSize));
+        assert(dstLen == static_cast<unsigned long>(unpackedSampleDataSize));
+      }
     }
 
     // decode sample


### PR DESCRIPTION
Hi Syoyo,

Nice library!  This addresses two bugs in LoadDeepEXR() that I found while trying to use it to read a deep image:

1) It failed to advance the marker position for the null byte at the end of the header.  The reading of the offset table was shifted by a byte.

2) Empty scanlines may have no sample data to decompress.  Taking the address of the data in a zero-length vector (`&sample_data.at(0)`) is invalid in this case.

Cheers,
\- Andrew