### PR TITLE
Add ignore-alpha option to hdr2ldr example

### DIFF
--- a/examples/exr2ldr/exr2ldr.cc
+++ b/examples/exr2ldr/exr2ldr.cc
@@ -19,13 +19,22 @@ inline unsigned char ftouc(float f, float gamma)
   return static_cast<unsigned char>(i);
 }
 
-bool SaveImage(const char* filename, const float* rgba, float scale, float gamma, int width, int height) {
+bool SaveImage(const char* filename, const float* rgba, float scale, float gamma, int width, int height, bool ignore_alpha) {
 
   std::vector<unsigned char> dst(width * height * 4);
 
   // alpha channel is also affected by `scale` parameter.
-  for (size_t i = 0; i < width * height * 4; i++) {
-    dst[i] = ftouc(rgba[i] * scale, gamma);
+  if(ignore_alpha) {
+    for (size_t i = 0; i < width * height; i++) {
+        dst[i * 4 + 0] = ftouc(rgba[i * 4 + 0] * scale, gamma);
+        dst[i * 4 + 1] = ftouc(rgba[i * 4 + 1] * scale, gamma);
+        dst[i * 4 + 2] = ftouc(rgba[i * 4 + 2] * scale, gamma);
+        dst[i * 4 + 3] = 255;
+    }
+  } else {
+    for (size_t i = 0; i < width * height * 4; i++) {
+        dst[i] = ftouc(rgba[i] * scale, gamma);
+    }
   }
 
   int ret = stbi_write_png(filename, width, height, 4, static_cast<const void*>(dst.data()), width * 4);
@@ -36,11 +45,12 @@ bool SaveImage(const char* filename, const float* rgba, float scale, float gamma
 int main(int argc, char** argv)
 {
   if (argc < 3) {
-    printf("Usage: exr2ldr input.exr output.png (scale) (resize_factor) (gammavalue).\n");
+    printf("Usage: exr2ldr input.exr output.png (scale) (resize_factor) (gammavalue) (-i or --ignore-alpha).\n");
     printf("    Pixel value [0.0, 1.0] in EXR is mapped to [0, 255] for LDR image.\n");
     printf("    You can adjust pixel value by `scale`(default = 1.0).\n");
     printf("    Resize image using `resize_factor`(default = 1.0). 2 = create half size image, 4 = 1/4 image, and so on\n");
     printf("    gammmavalue will be used for gamma correction when saving png image(default = 1.0).\n");
+    printf("    Ignore alpha value of input using -i or --ignore-alpha flag, and alpha of output is set to 255.\n");
     exit(-1);
   }
 
@@ -57,6 +67,11 @@ int main(int argc, char** argv)
   float gamma = 1.0f;
   if (argc > 5) {
     gamma = atof(argv[5]);
+  }
+
+  bool ignore_alpha = false;
+  if (argc > 6 && (strcmp(argv[6], "-i") == 0 || strcmp(argv[6], "--ignore-alpha") == 0)) {
+    ignore_alpha = true;
   }
     
   int width, height;
@@ -79,7 +94,7 @@ int main(int argc, char** argv)
   int ret = stbir_resize_float(rgba, width, height, width*4*sizeof(float), &buf.at(0), dst_width, dst_height,dst_width*4*sizeof(float), 4);
   assert(ret != 0);
 
-  bool ok = SaveImage(argv[2], &buf.at(0), scale, gamma, dst_width, dst_height);
+  bool ok = SaveImage(argv[2], &buf.at(0), scale, gamma, dst_width, dst_height, ignore_alpha);
 
   return (ok ? 0 : -1);
 }


### PR DESCRIPTION
This will add a flag to ignore alpha value of an input image. Alpha of an output image is set to 255.
Usage: ```exr2ldr input.exr output.png (scale) (resize_factor) (gammavalue) (-i or --ignore-alpha) ```