### PR TITLE
fixed error handling for zero output memory

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -11979,8 +11979,10 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
             sizeof(tinyexr::tinyexr_uint64) * static_cast<size_t>(num_blocks));
   }
 
-  tinyexr::SetErrorMessage("Output memory size is zero", err);
-  return 0;
+  if ( memory.size() == 0 ) {
+    tinyexr::SetErrorMessage("Output memory size is zero", err);
+    return 0;
+  }
 
   (*memory_out) = static_cast<unsigned char *>(malloc( totalSize ));
   memcpy( (*memory_out), &memory.at( 0 ), memory.size() );


### PR DESCRIPTION
SaveEXRImageToMemory left before writing the buffer because of a missing check.