### PR TITLE
Fixes warning C5208 (VS2019 16.6.0).

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -7398,7 +7398,7 @@ typedef struct {
   unsigned char pad[3];
 } ChannelInfo;
 
-typedef struct {
+struct HeaderInfo {
   std::vector<tinyexr::ChannelInfo> channels;
   std::vector<EXRAttribute> attributes;
 
@@ -7450,7 +7450,7 @@ typedef struct {
     header_len = 0;
     compression_type = 0;
   }
-} HeaderInfo;
+};
 
 static bool ReadChannelInfo(std::vector<ChannelInfo> &channels,
                             const std::vector<unsigned char> &data) {


### PR DESCRIPTION
When compiling with vs2019 16.6.0, we have 
`
tinyexr\tinyexr.h(7401,16): warning C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes`

This warning becomes an error when `/Wx` is set.