### PR TITLE
Fix little endian macro when used without miniz

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -7022,6 +7022,13 @@ void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename,
 
 // Reuse MINIZ_LITTE_ENDIAN macro
 
+#if defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || \
+    defined(__i386) || defined(__i486__) || defined(__i486) ||  \
+    defined(i386) || defined(__ia64__) || defined(__x86_64__)
+// MINIZ_X86_OR_X64_CPU is only used to help set the below macros.
+#define MINIZ_X86_OR_X64_CPU 1
+#endif
+
 #if defined(__sparcv9)
 // Big endian
 #else


### PR DESCRIPTION
Hey, thanks for this awesome library!
When using it without MINIZ, the definition of MINIZ_LITTLE_ENDIAN reused throughout tinyexr depends on the MINIZ_X86_OR_X64_CPU macro which is only defined in miniz and not in the `#else` block. Therefore little endianess might probably have been not detected on some platforms when used without miniz. This should fix it.