### PR TITLE
Fuzzing/Warning/Formatting fixes

### DIFF
--- a/test/unit/tester.cc
+++ b/test/unit/tester.cc
@@ -493,23 +493,23 @@ TEST_CASE("Beachball/multipart.0001.exr|Load", "[Load]") {
 
   REQUIRE(10 == num_exr_headers);
 
-  std::vector<EXRImage> images(num_exr_headers);
+  std::vector<EXRImage> images(static_cast<size_t>(num_exr_headers));
   for (int i = 0; i < num_exr_headers; i++) {
-    InitEXRImage(&images[i]);
+    InitEXRImage(&images[static_cast<size_t>(i)]);
   }
 
   ret = LoadEXRMultipartImageFromFile(
       &images.at(0), const_cast<const EXRHeader**>(exr_headers),
-      num_exr_headers, filepath.c_str(), &err);
+      static_cast<unsigned int>(num_exr_headers), filepath.c_str(), &err);
   REQUIRE(TINYEXR_SUCCESS == ret);
 
   for (int i = 0; i < num_exr_headers; i++) {
-    FreeEXRImage(&images.at(i));
+    FreeEXRImage(&images.at(static_cast<size_t>(i)));
   }
 
   for (int i = 0; i < num_exr_headers; i++) {
-    FreeEXRHeader(exr_headers[i]);  // free content
-    free(exr_headers[i]);           // free pointer
+    FreeEXRHeader(exr_headers[static_cast<size_t>(i)]);  // free content
+    free(exr_headers[static_cast<size_t>(i)]);           // free pointer
   }
   free(exr_headers);
 }
@@ -541,23 +541,23 @@ TEST_CASE("Beachbal multiparts", "[Load]") {
 
     REQUIRE(10 == num_exr_headers);
 
-    std::vector<EXRImage> images(num_exr_headers);
-    for (int i = 0; i < num_exr_headers; i++) {
-      InitEXRImage(&images[i]);
+    std::vector<EXRImage> images(static_cast<size_t>(num_exr_headers));
+    for (int j = 0; j < num_exr_headers; j++) {
+      InitEXRImage(&images[static_cast<size_t>(j)]);
     }
 
     ret = LoadEXRMultipartImageFromFile(
         &images.at(0), const_cast<const EXRHeader**>(exr_headers),
-        num_exr_headers, filepath.c_str(), &err);
+        static_cast<unsigned int>(num_exr_headers), filepath.c_str(), &err);
     REQUIRE(TINYEXR_SUCCESS == ret);
 
-    for (int i = 0; i < num_exr_headers; i++) {
-      FreeEXRImage(&images.at(i));
+    for (int j = 0; j < num_exr_headers; j++) {
+      FreeEXRImage(&images.at(static_cast<size_t>(j)));
     }
 
-    for (int i = 0; i < num_exr_headers; i++) {
-      FreeEXRHeader(exr_headers[i]);
-      free(exr_headers[i]);
+    for (int j = 0; j < num_exr_headers; j++) {
+      FreeEXRHeader(exr_headers[static_cast<size_t>(j)]);
+      free(exr_headers[static_cast<size_t>(j)]);
     }
     free(exr_headers);
   }
@@ -707,13 +707,13 @@ TEST_CASE("Compressed is smaller than uncompressed", "[Issue40]") {
       images[0],
   };
 
-  image.images = (unsigned char**)image_ptr;
+  image.images = const_cast<unsigned char**>(reinterpret_cast<const unsigned char*const *>(image_ptr));
   image.width = 1;
   image.height = 1;
 
   header.num_channels = 3;
   header.channels =
-      (EXRChannelInfo*)malloc(sizeof(EXRChannelInfo) * header.num_channels);
+      static_cast<EXRChannelInfo*>(malloc(sizeof(EXRChannelInfo) * static_cast<size_t>(header.num_channels)));
   // Must be BGR(A) order, since most of EXR viewers expect this channel order.
   strncpy(header.channels[0].name, "B", 255);
   header.channels[0].name[strlen("B")] = '\0';
@@ -722,9 +722,9 @@ TEST_CASE("Compressed is smaller than uncompressed", "[Issue40]") {
   strncpy(header.channels[2].name, "R", 255);
   header.channels[2].name[strlen("R")] = '\0';
 
-  header.pixel_types = (int*)malloc(sizeof(int) * header.num_channels);
+  header.pixel_types = static_cast<int*>(malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
   header.requested_pixel_types =
-      (int*)malloc(sizeof(int) * header.num_channels);
+      static_cast<int*>(malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
   for (int i = 0; i < header.num_channels; i++) {
     header.pixel_types[i] =
         TINYEXR_PIXELTYPE_FLOAT;  // pixel type of input image

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -65,7 +65,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // End of OpenEXR license -------------------------------------------------
 
-
 //
 //
 //   Do this:
@@ -198,11 +197,18 @@ typedef struct _EXRTile {
   unsigned char **images;  // image[channels][pixels]
 } EXRTile;
 
+typedef struct _EXRBox2i {
+  int min_x;
+  int min_y;
+  int max_x;
+  int max_y;
+} EXRBox2i;
+
 typedef struct _EXRHeader {
   float pixel_aspect_ratio;
   int line_order;
-  int data_window[4];
-  int display_window[4];
+  EXRBox2i data_window;
+  EXRBox2i display_window;
   float screen_window_center[2];
   float screen_window_width;
 
@@ -287,26 +293,29 @@ typedef struct _DeepImage {
 extern int LoadEXR(float **out_rgba, int *width, int *height,
                    const char *filename, const char **err);
 
-// Loads single-frame OpenEXR image by specifying layer name. Assume EXR image contains A(single channel
-// alpha) or RGB(A) channels.
-// Application must free image data as returned by `out_rgba`
-// Result image format is: float x RGBA x width x hight
-// Returns negative value and may set error string in `err` when there's an
-// error
-// When the specified layer name is not found in the EXR file, the function will return `TINYEXR_ERROR_LAYER_NOT_FOUND`.
+// Loads single-frame OpenEXR image by specifying layer name. Assume EXR image
+// contains A(single channel alpha) or RGB(A) channels. Application must free
+// image data as returned by `out_rgba` Result image format is: float x RGBA x
+// width x hight Returns negative value and may set error string in `err` when
+// there's an error When the specified layer name is not found in the EXR file,
+// the function will return `TINYEXR_ERROR_LAYER_NOT_FOUND`.
 extern int LoadEXRWithLayer(float **out_rgba, int *width, int *height,
-                   const char *filename, const char *layer_name, const char **err);
+                            const char *filename, const char *layer_name,
+                            const char **err);
 
 //
 // Get layer infos from EXR file.
 //
-// @param[out] layer_names List of layer names. Application must free memory after using this.
+// @param[out] layer_names List of layer names. Application must free memory
+// after using this.
 // @param[out] num_layers The number of layers
-// @param[out] err Error string(will be filled when the function returns error code). Free it using FreeEXRErrorMessage after using this value.
+// @param[out] err Error string(will be filled when the function returns error
+// code). Free it using FreeEXRErrorMessage after using this value.
 //
 // @return TINYEXR_SUCCEES upon success.
 //
-extern int EXRLayers(const char *filename, const char **layer_names[], int *num_layers, const char **err);
+extern int EXRLayers(const char *filename, const char **layer_names[],
+                     int *num_layers, const char **err);
 
 // @deprecated { to be removed. }
 // Simple wrapper API for ParseEXRHeaderFromFile.
@@ -7143,6 +7152,36 @@ static void swap4(unsigned int *val) {
 #endif
 }
 
+static void swap4(int *val) {
+#ifdef MINIZ_LITTLE_ENDIAN
+  (void)val;
+#else
+  int tmp = *val;
+  unsigned char *dst = reinterpret_cast<unsigned char *>(val);
+  unsigned char *src = reinterpret_cast<unsigned char *>(&tmp);
+
+  dst[0] = src[3];
+  dst[1] = src[2];
+  dst[2] = src[1];
+  dst[3] = src[0];
+#endif
+}
+
+static void swap4(float *val) {
+#ifdef MINIZ_LITTLE_ENDIAN
+  (void)val;
+#else
+  float tmp = *val;
+  unsigned char *dst = reinterpret_cast<unsigned char *>(val);
+  unsigned char *src = reinterpret_cast<unsigned char *>(&tmp);
+
+  dst[0] = src[3];
+  dst[1] = src[2];
+  dst[2] = src[1];
+  dst[3] = src[0];
+#endif
+}
+
 #if 0
 static void cpy8(tinyexr::tinyexr_uint64 *dst_val, const tinyexr::tinyexr_uint64 *src_val) {
   unsigned char *dst = reinterpret_cast<unsigned char *>(dst_val);
@@ -7390,7 +7429,7 @@ static void WriteAttributeToMemory(std::vector<unsigned char> *out,
   out->insert(out->end(), type, type + strlen(type) + 1);
 
   int outLen = len;
-  tinyexr::swap4(reinterpret_cast<unsigned int *>(&outLen));
+  tinyexr::swap4(&outLen);
   out->insert(out->end(), reinterpret_cast<unsigned char *>(&outLen),
               reinterpret_cast<unsigned char *>(&outLen) + sizeof(int));
   out->insert(out->end(), data, data + len);
@@ -7405,13 +7444,20 @@ typedef struct {
   unsigned char pad[3];
 } ChannelInfo;
 
+typedef struct {
+  int min_x;
+  int min_y;
+  int max_x;
+  int max_y;
+} Box2iInfo;
+
 struct HeaderInfo {
   std::vector<tinyexr::ChannelInfo> channels;
   std::vector<EXRAttribute> attributes;
 
-  int data_window[4];
+  Box2iInfo data_window;
   int line_order;
-  int display_window[4];
+  Box2iInfo display_window;
   float screen_window_center[2];
   float screen_window_width;
   float pixel_aspect_ratio;
@@ -7432,15 +7478,15 @@ struct HeaderInfo {
     channels.clear();
     attributes.clear();
 
-    data_window[0] = 0;
-    data_window[1] = 0;
-    data_window[2] = 0;
-    data_window[3] = 0;
+    data_window.min_x = 0;
+    data_window.min_y = 0;
+    data_window.max_x = 0;
+    data_window.max_y = 0;
     line_order = 0;
-    display_window[0] = 0;
-    display_window[1] = 0;
-    display_window[2] = 0;
-    display_window[3] = 0;
+    display_window.min_x = 0;
+    display_window.min_y = 0;
+    display_window.max_x = 0;
+    display_window.max_y = 0;
     screen_window_center[0] = 0.0f;
     screen_window_center[1] = 0.0f;
     screen_window_width = 0.0f;
@@ -7496,9 +7542,9 @@ static bool ReadChannelInfo(std::vector<ChannelInfo> &channels,
     memcpy(&info.y_sampling, p, sizeof(int));  // int
     p += 4;
 
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&info.pixel_type));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&info.x_sampling));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&info.y_sampling));
+    tinyexr::swap4(&info.pixel_type);
+    tinyexr::swap4(&info.x_sampling);
+    tinyexr::swap4(&info.y_sampling);
 
     channels.push_back(info);
   }
@@ -7528,9 +7574,9 @@ static void WriteChannelInfo(std::vector<unsigned char> &data,
     int pixel_type = channels[c].pixel_type;
     int x_sampling = channels[c].x_sampling;
     int y_sampling = channels[c].y_sampling;
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&pixel_type));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&x_sampling));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&y_sampling));
+    tinyexr::swap4(&pixel_type);
+    tinyexr::swap4(&x_sampling);
+    tinyexr::swap4(&y_sampling);
 
     memcpy(p, &pixel_type, sizeof(int));
     p += sizeof(int);
@@ -9536,9 +9582,8 @@ struct ZFPCompressionParam {
 };
 
 static bool FindZFPCompressionParam(ZFPCompressionParam *param,
-                             const EXRAttribute *attributes,
-                             int num_attributes,
-                             std::string *err) {
+                                    const EXRAttribute *attributes,
+                                    int num_attributes, std::string *err) {
   bool foundType = false;
 
   for (int i = 0; i < num_attributes; i++) {
@@ -9549,7 +9594,8 @@ static bool FindZFPCompressionParam(ZFPCompressionParam *param,
         break;
       } else {
         if (err) {
-          (*err) += "zfpCompressionType attribute must be uchar(1 byte) type.\n";
+          (*err) +=
+              "zfpCompressionType attribute must be uchar(1 byte) type.\n";
         }
         return false;
       }
@@ -9615,7 +9661,8 @@ static bool DecompressZfp(float *dst, int dst_width, int dst_num_lines,
                           size_t num_channels, const unsigned char *src,
                           unsigned long src_size,
                           const ZFPCompressionParam &param) {
-  size_t uncompressed_size = size_t(dst_width) * size_t(dst_num_lines) * num_channels;
+  size_t uncompressed_size =
+      size_t(dst_width) * size_t(dst_num_lines) * num_channels;
 
   if (uncompressed_size == src_size) {
     // Data is not compressed(Issue 40).
@@ -9634,7 +9681,9 @@ static bool DecompressZfp(float *dst, int dst_width, int dst_num_lines,
 
   field =
       zfp_field_2d(reinterpret_cast<void *>(const_cast<unsigned char *>(src)),
-                   zfp_type_float, static_cast<unsigned int>(dst_width), static_cast<unsigned int>(dst_num_lines) * static_cast<unsigned int>(num_channels));
+                   zfp_type_float, static_cast<unsigned int>(dst_width),
+                   static_cast<unsigned int>(dst_num_lines) *
+                       static_cast<unsigned int>(num_channels));
   zfp = zfp_stream_open(NULL);
 
   if (param.type == TINYEXR_ZFP_COMPRESSIONTYPE_RATE) {
@@ -9682,9 +9731,10 @@ static bool DecompressZfp(float *dst, int dst_width, int dst_num_lines,
 }
 
 // Assume pixel format is FLOAT for all channels.
-static bool CompressZfp(std::vector<unsigned char> *outBuf, unsigned int *outSize,
-                 const float *inPtr, int width, int num_lines, int num_channels,
-                 const ZFPCompressionParam &param) {
+static bool CompressZfp(std::vector<unsigned char> *outBuf,
+                        unsigned int *outSize, const float *inPtr, int width,
+                        int num_lines, int num_channels,
+                        const ZFPCompressionParam &param) {
   zfp_stream *zfp = NULL;
   zfp_field *field = NULL;
 
@@ -9697,7 +9747,8 @@ static bool CompressZfp(std::vector<unsigned char> *outBuf, unsigned int *outSiz
 
   // create input array.
   field = zfp_field_2d(reinterpret_cast<void *>(const_cast<float *>(inPtr)),
-                       zfp_type_float, static_cast<unsigned int>(width), static_cast<unsigned int>(num_lines * num_channels));
+                       zfp_type_float, static_cast<unsigned int>(width),
+                       static_cast<unsigned int>(num_lines * num_channels));
 
   zfp = zfp_stream_open(NULL);
 
@@ -10180,7 +10231,7 @@ static bool DecodePixelData(/* out */ unsigned char **out_images,
     tinyexr::ZFPCompressionParam zfp_compression_param;
     std::string e;
     if (!tinyexr::FindZFPCompressionParam(&zfp_compression_param, attributes,
-                                 int(num_attributes), &e)) {
+                                          int(num_attributes), &e)) {
       // This code path should not be reachable.
       assert(0);
       return false;
@@ -10381,8 +10432,11 @@ static bool DecodeTiledPixelData(
     const EXRAttribute *attributes, size_t num_channels,
     const EXRChannelInfo *channels,
     const std::vector<size_t> &channel_offset_list) {
-  assert(tile_offset_x * tile_size_x < data_width);
-  assert(tile_offset_y * tile_size_y < data_height);
+  if (tile_size_x > data_width || tile_size_y > data_height ||
+      tile_size_x * tile_offset_x > data_width ||
+      tile_size_y * tile_offset_y > data_height) {
+    return false;
+  }
 
   // Compute actual image size in a tile.
   if ((tile_offset_x + 1) * tile_size_x >= data_width) {
@@ -10487,7 +10541,6 @@ static inline std::wstring UTF8ToWchar(const std::string &str) {
 }
 #endif
 
-
 static int ParseEXRHeader(HeaderInfo *info, bool *empty_header,
                           const EXRVersion *version, std::string *err,
                           const unsigned char *buf, size_t size) {
@@ -10527,15 +10580,15 @@ static int ParseEXRHeader(HeaderInfo *info, bool *empty_header,
   bool has_screen_window_center = false;
   bool has_screen_window_width = false;
 
-  info->data_window[0] = 0;
-  info->data_window[1] = 0;
-  info->data_window[2] = 0;
-  info->data_window[3] = 0;
+  info->data_window.min_x = 0;
+  info->data_window.min_y = 0;
+  info->data_window.max_x = 0;
+  info->data_window.max_y = 0;
   info->line_order = 0;  // @fixme
-  info->display_window[0] = 0;
-  info->display_window[1] = 0;
-  info->display_window[2] = 0;
-  info->display_window[3] = 0;
+  info->display_window.min_x = 0;
+  info->display_window.min_y = 0;
+  info->display_window.max_x = 0;
+  info->display_window.max_y = 0;
   info->screen_window_center[0] = 0.0f;
   info->screen_window_center[1] = 0.0f;
   info->screen_window_width = -1.0f;
@@ -10584,6 +10637,14 @@ static int ParseEXRHeader(HeaderInfo *info, bool *empty_header,
       tile_mode = data[8];
       tinyexr::swap4(&x_size);
       tinyexr::swap4(&y_size);
+
+      if (x_size > static_cast<unsigned int>(std::numeric_limits<int>::max()) ||
+          y_size > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
+        if (err) {
+          (*err) = "Tile sizes were invalid.";
+        }
+        return TINYEXR_ERROR_UNSUPPORTED_FORMAT;
+      }
 
       info->tile_size_x = static_cast<int>(x_size);
       info->tile_size_y = static_cast<int>(y_size);
@@ -10656,30 +10717,26 @@ static int ParseEXRHeader(HeaderInfo *info, bool *empty_header,
 
     } else if (attr_name.compare("dataWindow") == 0) {
       if (data.size() >= 16) {
-        memcpy(&info->data_window[0], &data.at(0), sizeof(int));
-        memcpy(&info->data_window[1], &data.at(4), sizeof(int));
-        memcpy(&info->data_window[2], &data.at(8), sizeof(int));
-        memcpy(&info->data_window[3], &data.at(12), sizeof(int));
-        tinyexr::swap4(reinterpret_cast<unsigned int *>(&info->data_window[0]));
-        tinyexr::swap4(reinterpret_cast<unsigned int *>(&info->data_window[1]));
-        tinyexr::swap4(reinterpret_cast<unsigned int *>(&info->data_window[2]));
-        tinyexr::swap4(reinterpret_cast<unsigned int *>(&info->data_window[3]));
+        memcpy(&info->data_window.min_x, &data.at(0), sizeof(int));
+        memcpy(&info->data_window.min_y, &data.at(4), sizeof(int));
+        memcpy(&info->data_window.max_x, &data.at(8), sizeof(int));
+        memcpy(&info->data_window.max_y, &data.at(12), sizeof(int));
+        tinyexr::swap4(&info->data_window.min_x);
+        tinyexr::swap4(&info->data_window.min_y);
+        tinyexr::swap4(&info->data_window.max_x);
+        tinyexr::swap4(&info->data_window.max_y);
         has_data_window = true;
       }
     } else if (attr_name.compare("displayWindow") == 0) {
       if (data.size() >= 16) {
-        memcpy(&info->display_window[0], &data.at(0), sizeof(int));
-        memcpy(&info->display_window[1], &data.at(4), sizeof(int));
-        memcpy(&info->display_window[2], &data.at(8), sizeof(int));
-        memcpy(&info->display_window[3], &data.at(12), sizeof(int));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->display_window[0]));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->display_window[1]));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->display_window[2]));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->display_window[3]));
+        memcpy(&info->display_window.min_x, &data.at(0), sizeof(int));
+        memcpy(&info->display_window.min_y, &data.at(4), sizeof(int));
+        memcpy(&info->display_window.max_x, &data.at(8), sizeof(int));
+        memcpy(&info->display_window.max_y, &data.at(12), sizeof(int));
+        tinyexr::swap4(&info->display_window.min_x);
+        tinyexr::swap4(&info->display_window.min_y);
+        tinyexr::swap4(&info->display_window.max_x);
+        tinyexr::swap4(&info->display_window.max_y);
 
         has_display_window = true;
       }
@@ -10691,32 +10748,28 @@ static int ParseEXRHeader(HeaderInfo *info, bool *empty_header,
     } else if (attr_name.compare("pixelAspectRatio") == 0) {
       if (data.size() >= sizeof(float)) {
         memcpy(&info->pixel_aspect_ratio, &data.at(0), sizeof(float));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->pixel_aspect_ratio));
+        tinyexr::swap4(&info->pixel_aspect_ratio);
         has_pixel_aspect_ratio = true;
       }
     } else if (attr_name.compare("screenWindowCenter") == 0) {
       if (data.size() >= 8) {
         memcpy(&info->screen_window_center[0], &data.at(0), sizeof(float));
         memcpy(&info->screen_window_center[1], &data.at(4), sizeof(float));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->screen_window_center[0]));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->screen_window_center[1]));
+        tinyexr::swap4(&info->screen_window_center[0]);
+        tinyexr::swap4(&info->screen_window_center[1]);
         has_screen_window_center = true;
       }
     } else if (attr_name.compare("screenWindowWidth") == 0) {
       if (data.size() >= sizeof(float)) {
         memcpy(&info->screen_window_width, &data.at(0), sizeof(float));
-        tinyexr::swap4(
-            reinterpret_cast<unsigned int *>(&info->screen_window_width));
+        tinyexr::swap4(&info->screen_window_width);
 
         has_screen_window_width = true;
       }
     } else if (attr_name.compare("chunkCount") == 0) {
       if (data.size() >= sizeof(int)) {
         memcpy(&info->chunk_count, &data.at(0), sizeof(int));
-        tinyexr::swap4(reinterpret_cast<unsigned int *>(&info->chunk_count));
+        tinyexr::swap4(&info->chunk_count);
       }
     } else {
       // Custom attribute(up to TINYEXR_MAX_CUSTOM_ATTRIBUTES)
@@ -10802,14 +10855,14 @@ static void ConvertHeader(EXRHeader *exr_header, const HeaderInfo &info) {
   exr_header->screen_window_center[1] = info.screen_window_center[1];
   exr_header->screen_window_width = info.screen_window_width;
   exr_header->chunk_count = info.chunk_count;
-  exr_header->display_window[0] = info.display_window[0];
-  exr_header->display_window[1] = info.display_window[1];
-  exr_header->display_window[2] = info.display_window[2];
-  exr_header->display_window[3] = info.display_window[3];
-  exr_header->data_window[0] = info.data_window[0];
-  exr_header->data_window[1] = info.data_window[1];
-  exr_header->data_window[2] = info.data_window[2];
-  exr_header->data_window[3] = info.data_window[3];
+  exr_header->display_window.min_x = info.display_window.min_x;
+  exr_header->display_window.min_y = info.display_window.min_y;
+  exr_header->display_window.max_x = info.display_window.max_x;
+  exr_header->display_window.max_y = info.display_window.max_y;
+  exr_header->data_window.min_x = info.data_window.min_x;
+  exr_header->data_window.min_y = info.data_window.min_y;
+  exr_header->data_window.max_x = info.data_window.max_x;
+  exr_header->data_window.max_y = info.data_window.max_y;
   exr_header->line_order = info.line_order;
   exr_header->compression_type = info.compression_type;
 
@@ -10895,26 +10948,26 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
 
 #if TINYEXR_USE_ZFP
     tinyexr::ZFPCompressionParam zfp_compression_param;
-    if (!FindZFPCompressionParam(&zfp_compression_param, exr_header->custom_attributes,
-                                   int(exr_header->num_custom_attributes), err)) {
+    if (!FindZFPCompressionParam(&zfp_compression_param,
+                                 exr_header->custom_attributes,
+                                 int(exr_header->num_custom_attributes), err)) {
       return TINYEXR_ERROR_INVALID_HEADER;
     }
 #endif
   }
 
-
-  int data_width = exr_header->data_window[2] - exr_header->data_window[0] + 1;
-  int data_height = exr_header->data_window[3] - exr_header->data_window[1] + 1;
-
-  if ((data_width < 0) || (data_height < 0)) {
+  if (exr_header->data_window.max_x < exr_header->data_window.min_x ||
+      exr_header->data_window.max_y < exr_header->data_window.min_y) {
     if (err) {
-      std::stringstream ss;
-      ss << "Invalid data width or data height: " << data_width << ", "
-         << data_height << std::endl;
-      (*err) += ss.str();
+      (*err) += "Invalid data window.\n";
     }
     return TINYEXR_ERROR_INVALID_DATA;
   }
+
+  int data_width =
+      exr_header->data_window.max_x - exr_header->data_window.min_x + 1;
+  int data_height =
+      exr_header->data_window.max_y - exr_header->data_window.min_y + 1;
 
   // Do not allow too large data_width and data_height. header invalid?
   {
@@ -11017,14 +11070,10 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
 
           int tile_coordinates[4];
           memcpy(tile_coordinates, data_ptr, sizeof(int) * 4);
-          tinyexr::swap4(
-              reinterpret_cast<unsigned int *>(&tile_coordinates[0]));
-          tinyexr::swap4(
-              reinterpret_cast<unsigned int *>(&tile_coordinates[1]));
-          tinyexr::swap4(
-              reinterpret_cast<unsigned int *>(&tile_coordinates[2]));
-          tinyexr::swap4(
-              reinterpret_cast<unsigned int *>(&tile_coordinates[3]));
+          tinyexr::swap4(&tile_coordinates[0]);
+          tinyexr::swap4(&tile_coordinates[1]);
+          tinyexr::swap4(&tile_coordinates[2]);
+          tinyexr::swap4(&tile_coordinates[3]);
 
           // @todo{ LoD }
           if (tile_coordinates[2] != 0) {
@@ -11039,7 +11088,7 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
           int data_len;
           memcpy(&data_len, data_ptr + 16,
                  sizeof(int));  // 16 = sizeof(tile_coordinates)
-          tinyexr::swap4(reinterpret_cast<unsigned int *>(&data_len));
+          tinyexr::swap4(&data_len);
 
           if (data_len < 4 || size_t(data_len) > data_size) {
             // TODO(LTE): atomic
@@ -11160,8 +11209,8 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
             memcpy(&line_no, data_ptr, sizeof(int));
             int data_len;
             memcpy(&data_len, data_ptr + 4, sizeof(int));
-            tinyexr::swap4(reinterpret_cast<unsigned int *>(&line_no));
-            tinyexr::swap4(reinterpret_cast<unsigned int *>(&data_len));
+            tinyexr::swap4(&line_no);
+            tinyexr::swap4(&data_len);
 
             if (size_t(data_len) > data_size) {
               invalid_data = true;
@@ -11177,7 +11226,7 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
             } else {
               // line_no may be negative.
               int end_line_no = (std::min)(line_no + num_scanline_blocks,
-                                           (exr_header->data_window[3] + 1));
+                                           (exr_header->data_window.max_y + 1));
 
               int num_lines = end_line_no - line_no;
 
@@ -11192,13 +11241,13 @@ static int DecodeChunk(EXRImage *exr_image, const EXRHeader *exr_header,
                 // overflow check
                 tinyexr_int64 lno =
                     static_cast<tinyexr_int64>(line_no) -
-                    static_cast<tinyexr_int64>(exr_header->data_window[1]);
+                    static_cast<tinyexr_int64>(exr_header->data_window.min_y);
                 if (lno > std::numeric_limits<int>::max()) {
                   line_no = -1;  // invalid
                 } else if (lno < -std::numeric_limits<int>::max()) {
                   line_no = -1;  // invalid
                 } else {
-                  line_no -= exr_header->data_window[1];
+                  line_no -= exr_header->data_window.min_y;
                 }
 
                 if (line_no < 0) {
@@ -11283,8 +11332,8 @@ static bool ReconstructLineOffsets(
       return false;
     }
 
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&y));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&data_len));
+    tinyexr::swap4(&y);
+    tinyexr::swap4(&data_len);
 
     (*offsets)[i] = offset;
 
@@ -11313,25 +11362,24 @@ static int DecodeEXRImage(EXRImage *exr_image, const EXRHeader *exr_header,
     num_scanline_blocks = 16;
   }
 
-  int data_width = exr_header->data_window[2] - exr_header->data_window[0];
-  if (data_width >= std::numeric_limits<int>::max()) {
+  if (exr_header->data_window.max_x < exr_header->data_window.min_x ||
+      exr_header->data_window.max_x - exr_header->data_window.min_x ==
+          std::numeric_limits<int>::max()) {
     // Issue 63
     tinyexr::SetErrorMessage("Invalid data width value", err);
     return TINYEXR_ERROR_INVALID_DATA;
   }
-  data_width++;
+  int data_width =
+      exr_header->data_window.max_x - exr_header->data_window.min_x + 1;
 
-  int data_height = exr_header->data_window[3] - exr_header->data_window[1];
-  if (data_height >= std::numeric_limits<int>::max()) {
+  if (exr_header->data_window.max_y < exr_header->data_window.min_y ||
+      exr_header->data_window.max_y - exr_header->data_window.min_y ==
+          std::numeric_limits<int>::max()) {
     tinyexr::SetErrorMessage("Invalid data height value", err);
     return TINYEXR_ERROR_INVALID_DATA;
   }
-  data_height++;
-
-  if ((data_width < 0) || (data_height < 0)) {
-    tinyexr::SetErrorMessage("data width or data height is negative.", err);
-    return TINYEXR_ERROR_INVALID_DATA;
-  }
+  int data_height =
+      exr_header->data_window.max_y - exr_header->data_window.min_y + 1;
 
   // Do not allow too large data_width and data_height. header invalid?
   {
@@ -11354,6 +11402,12 @@ static int DecodeEXRImage(EXRImage *exr_image, const EXRHeader *exr_header,
     num_blocks = static_cast<size_t>(exr_header->chunk_count);
   } else if (exr_header->tiled) {
     // @todo { LoD }
+    if (exr_header->tile_size_x > data_width || exr_header->tile_size_x < 1 ||
+        exr_header->tile_size_y > data_height || exr_header->tile_size_y < 1) {
+      tinyexr::SetErrorMessage("tile sizes are invalid.", err);
+      return TINYEXR_ERROR_INVALID_DATA;
+    }
+
     size_t num_x_tiles = static_cast<size_t>(data_width) /
                          static_cast<size_t>(exr_header->tile_size_x);
     if (num_x_tiles * static_cast<size_t>(exr_header->tile_size_x) <
@@ -11450,7 +11504,8 @@ static int DecodeEXRImage(EXRImage *exr_image, const EXRHeader *exr_header,
   }
 }
 
-static void GetLayers(const EXRHeader& exr_header, std::vector<std::string>& layer_names) {
+static void GetLayers(const EXRHeader &exr_header,
+                      std::vector<std::string> &layer_names) {
   // Naive implementation
   // Group channels by layers
   // go over all channel names, split by periods
@@ -11461,22 +11516,22 @@ static void GetLayers(const EXRHeader& exr_header, std::vector<std::string>& lay
     const size_t pos = full_name.find_last_of('.');
     if (pos != std::string::npos && pos != 0 && pos + 1 < full_name.size()) {
       full_name.erase(pos);
-      if (std::find(layer_names.begin(), layer_names.end(), full_name) == layer_names.end())
+      if (std::find(layer_names.begin(), layer_names.end(), full_name) ==
+          layer_names.end())
         layer_names.push_back(full_name);
     }
   }
 }
 
 struct LayerChannel {
-  explicit LayerChannel (size_t i, std::string n)
-    : index(i)
-    , name(n)
-  {}
+  explicit LayerChannel(size_t i, std::string n) : index(i), name(n) {}
   size_t index;
   std::string name;
 };
 
-static void ChannelsInLayer(const EXRHeader& exr_header, const std::string layer_name, std::vector<LayerChannel>& channels) {
+static void ChannelsInLayer(const EXRHeader &exr_header,
+                            const std::string layer_name,
+                            std::vector<LayerChannel> &channels) {
   channels.clear();
   for (int c = 0; c < exr_header.num_channels; c++) {
     std::string ch_name(exr_header.channels[c].name);
@@ -11487,8 +11542,7 @@ static void ChannelsInLayer(const EXRHeader& exr_header, const std::string layer
       }
     } else {
       const size_t pos = ch_name.find(layer_name + '.');
-      if (pos == std::string::npos)
-        continue;
+      if (pos == std::string::npos) continue;
       if (pos == 0) {
         ch_name = ch_name.substr(layer_name.size() + 1);
       }
@@ -11500,7 +11554,8 @@ static void ChannelsInLayer(const EXRHeader& exr_header, const std::string layer
 
 }  // namespace tinyexr
 
-int EXRLayers(const char *filename, const char **layer_names[], int *num_layers, const char **err) {
+int EXRLayers(const char *filename, const char **layer_names[], int *num_layers,
+              const char **err) {
   EXRVersion exr_version;
   EXRHeader exr_header;
   InitEXRHeader(&exr_header);
@@ -11514,8 +11569,8 @@ int EXRLayers(const char *filename, const char **layer_names[], int *num_layers,
 
     if (exr_version.multipart || exr_version.non_image) {
       tinyexr::SetErrorMessage(
-        "Loading multipart or DeepImage is not supported  in LoadEXR() API",
-        err);
+          "Loading multipart or DeepImage is not supported  in LoadEXR() API",
+          err);
       return TINYEXR_ERROR_INVALID_DATA;  // @fixme.
     }
   }
@@ -11531,7 +11586,7 @@ int EXRLayers(const char *filename, const char **layer_names[], int *num_layers,
 
   (*num_layers) = int(layer_vec.size());
   (*layer_names) = static_cast<const char **>(
-    malloc(sizeof(const char *) * static_cast<size_t>(layer_vec.size())));
+      malloc(sizeof(const char *) * static_cast<size_t>(layer_vec.size())));
   for (size_t c = 0; c < static_cast<size_t>(layer_vec.size()); c++) {
 #ifdef _MSC_VER
     (*layer_names)[c] = _strdup(layer_vec[c].c_str());
@@ -11546,11 +11601,13 @@ int EXRLayers(const char *filename, const char **layer_names[], int *num_layers,
 
 int LoadEXR(float **out_rgba, int *width, int *height, const char *filename,
             const char **err) {
-  return LoadEXRWithLayer(out_rgba, width, height, filename, /* layername */NULL, err);
+  return LoadEXRWithLayer(out_rgba, width, height, filename,
+                          /* layername */ NULL, err);
 }
 
-int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *filename, const char *layername,
-            const char **err) {
+int LoadEXRWithLayer(float **out_rgba, int *width, int *height,
+                     const char *filename, const char *layername,
+                     const char **err) {
   if (out_rgba == NULL) {
     tinyexr::SetErrorMessage("Invalid argument for LoadEXR()", err);
     return TINYEXR_ERROR_INVALID_ARGUMENT;
@@ -11566,7 +11623,8 @@ int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *file
     int ret = ParseEXRVersionFromFile(&exr_version, filename);
     if (ret != TINYEXR_SUCCESS) {
       std::stringstream ss;
-      ss << "Failed to open EXR file or read version info from EXR file. code(" << ret << ")";
+      ss << "Failed to open EXR file or read version info from EXR file. code("
+         << ret << ")";
       tinyexr::SetErrorMessage(ss.str(), err);
       return ret;
     }
@@ -11613,7 +11671,8 @@ int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *file
   tinyexr::GetLayers(exr_header, layer_names);
 
   std::vector<tinyexr::LayerChannel> channels;
-  tinyexr::ChannelsInLayer(exr_header, layername == NULL ? "" : std::string(layername), channels);
+  tinyexr::ChannelsInLayer(
+      exr_header, layername == NULL ? "" : std::string(layername), channels);
 
   if (channels.size() < 1) {
     tinyexr::SetErrorMessage("Layer Not Found", err);
@@ -11628,14 +11687,11 @@ int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *file
 
     if (ch.name == "R") {
       idxR = int(ch.index);
-    }
-    else if (ch.name == "G") {
+    } else if (ch.name == "G") {
       idxG = int(ch.index);
-    }
-    else if (ch.name == "B") {
+    } else if (ch.name == "B") {
       idxB = int(ch.index);
-    }
-    else if (ch.name == "A") {
+    } else if (ch.name == "A") {
       idxA = int(ch.index);
     }
   }
@@ -11652,11 +11708,13 @@ int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *file
       for (int it = 0; it < exr_image.num_tiles; it++) {
         for (int j = 0; j < exr_header.tile_size_y; j++) {
           for (int i = 0; i < exr_header.tile_size_x; i++) {
-            const int ii =
-                exr_image.tiles[it].offset_x * exr_header.tile_size_x + i;
-            const int jj =
-                exr_image.tiles[it].offset_y * exr_header.tile_size_y + j;
-            const int idx = ii + jj * exr_image.width;
+            const int ii = exr_image.tiles[it].offset_x *
+                               static_cast<int>(exr_header.tile_size_x) +
+                           i;
+            const int jj = exr_image.tiles[it].offset_y *
+                               static_cast<int>(exr_header.tile_size_y) +
+                           j;
+            const int idx = ii + jj * static_cast<int>(exr_image.width);
 
             // out of region check.
             if (ii >= exr_image.width) {
@@ -11680,7 +11738,8 @@ int LoadEXRWithLayer(float **out_rgba, int *width, int *height, const char *file
       }
     } else {
       for (int i = 0; i < exr_image.width * exr_image.height; i++) {
-        const float val = reinterpret_cast<float **>(exr_image.images)[chIdx][i];
+        const float val =
+            reinterpret_cast<float **>(exr_image.images)[chIdx][i];
         (*out_rgba)[4 * i + 0] = val;
         (*out_rgba)[4 * i + 1] = val;
         (*out_rgba)[4 * i + 2] = val;
@@ -12028,8 +12087,9 @@ int LoadEXRImageFromFile(EXRImage *exr_image, const EXRHeader *exr_header,
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (errcode != 0) {
     tinyexr::SetErrorMessage("Cannot read file " + std::string(filename), err);
     // TODO(syoyo): return wfopen_s erro code
@@ -12190,7 +12250,7 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
   {
     int comp = exr_header->compression_type;
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&comp));
+    tinyexr::swap4(&comp);
     tinyexr::WriteAttributeToMemory(
         &memory, "compression", "compression",
         reinterpret_cast<const unsigned char *>(&comp), 1);
@@ -12198,10 +12258,10 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
   {
     int data[4] = {0, 0, exr_image->width - 1, exr_image->height - 1};
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&data[0]));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&data[1]));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&data[2]));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&data[3]));
+    tinyexr::swap4(&data[0]);
+    tinyexr::swap4(&data[1]);
+    tinyexr::swap4(&data[2]);
+    tinyexr::swap4(&data[3]);
     tinyexr::WriteAttributeToMemory(
         &memory, "dataWindow", "box2i",
         reinterpret_cast<const unsigned char *>(data), sizeof(int) * 4);
@@ -12218,7 +12278,7 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
   {
     float aspectRatio = 1.0f;
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&aspectRatio));
+    tinyexr::swap4(&aspectRatio);
     tinyexr::WriteAttributeToMemory(
         &memory, "pixelAspectRatio", "float",
         reinterpret_cast<const unsigned char *>(&aspectRatio), sizeof(float));
@@ -12226,8 +12286,8 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
   {
     float center[2] = {0.0f, 0.0f};
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&center[0]));
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&center[1]));
+    tinyexr::swap4(&center[0]);
+    tinyexr::swap4(&center[1]);
     tinyexr::WriteAttributeToMemory(
         &memory, "screenWindowCenter", "v2f",
         reinterpret_cast<const unsigned char *>(center), 2 * sizeof(float));
@@ -12235,7 +12295,7 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
   {
     float w = static_cast<float>(exr_image->width);
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&w));
+    tinyexr::swap4(&w);
     tinyexr::WriteAttributeToMemory(&memory, "screenWindowWidth", "float",
                                     reinterpret_cast<const unsigned char *>(&w),
                                     sizeof(float));
@@ -12347,7 +12407,7 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
 
               tinyexr::FP32 f32 = half_to_float(h16);
 
-              tinyexr::swap4(reinterpret_cast<unsigned int *>(&f32.f));
+              tinyexr::swap4(&f32.f);
 
               // line_ptr[x] = f32.f;
               tinyexr::cpy4(line_ptr + x, &(f32.f));
@@ -12411,7 +12471,7 @@ size_t SaveEXRImageToMemory(const EXRImage *exr_image,
               float val = reinterpret_cast<float **>(
                   exr_image->images)[c][(y + start_y) * exr_image->width + x];
 
-              tinyexr::swap4(reinterpret_cast<unsigned int *>(&val));
+              tinyexr::swap4(&val);
 
               // line_ptr[x] = val;
               tinyexr::cpy4(line_ptr + x, &val);
@@ -12630,10 +12690,12 @@ int SaveEXRImageToFile(const EXRImage *exr_image, const EXRHeader *exr_header,
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"wb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"wb");
   if (errcode != 0) {
-    tinyexr::SetErrorMessage("Cannot write a file: " + std::string(filename), err);
+    tinyexr::SetErrorMessage("Cannot write a file: " + std::string(filename),
+                             err);
     return TINYEXR_ERROR_CANT_WRITE_FILE;
   }
 #else
@@ -12644,7 +12706,8 @@ int SaveEXRImageToFile(const EXRImage *exr_image, const EXRHeader *exr_header,
   fp = fopen(filename, "wb");
 #endif
   if (!fp) {
-    tinyexr::SetErrorMessage("Cannot write a file: " + std::string(filename), err);
+    tinyexr::SetErrorMessage("Cannot write a file: " + std::string(filename),
+                             err);
     return TINYEXR_ERROR_CANT_WRITE_FILE;
   }
 
@@ -12678,8 +12741,9 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
 
 #ifdef _WIN32
   FILE *fp = NULL;
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (errcode != 0) {
     tinyexr::SetErrorMessage("Cannot read a file " + std::string(filename),
                              err);
@@ -12823,10 +12887,10 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
       memcpy(&dy, &data.at(4), sizeof(int));
       memcpy(&dw, &data.at(8), sizeof(int));
       memcpy(&dh, &data.at(12), sizeof(int));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&dx));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&dy));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&dw));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&dh));
+      tinyexr::swap4(&dx);
+      tinyexr::swap4(&dy);
+      tinyexr::swap4(&dw);
+      tinyexr::swap4(&dh);
 
     } else if (attr_name.compare("displayWindow") == 0) {
       int x;
@@ -12837,10 +12901,10 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
       memcpy(&y, &data.at(4), sizeof(int));
       memcpy(&w, &data.at(8), sizeof(int));
       memcpy(&h, &data.at(12), sizeof(int));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&x));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&y));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&w));
-      tinyexr::swap4(reinterpret_cast<unsigned int *>(&h));
+      tinyexr::swap4(&x);
+      tinyexr::swap4(&y);
+      tinyexr::swap4(&w);
+      tinyexr::swap4(&h);
     }
   }
 
@@ -12928,7 +12992,7 @@ int LoadDeepEXR(DeepImage *deep_image, const char *filename, const char **err) {
     memcpy(&unpackedSampleDataSize, data_ptr + 20,
            sizeof(tinyexr::tinyexr_int64));
 
-    tinyexr::swap4(reinterpret_cast<unsigned int *>(&line_no));
+    tinyexr::swap4(&line_no);
     tinyexr::swap8(
         reinterpret_cast<tinyexr::tinyexr_uint64 *>(&packedOffsetTableSize));
     tinyexr::swap8(
@@ -13165,8 +13229,9 @@ int ParseEXRHeaderFromFile(EXRHeader *exr_header, const EXRVersion *exr_version,
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (errcode != 0) {
     tinyexr::SetErrorMessage("Cannot read file " + std::string(filename), err);
     return TINYEXR_ERROR_INVALID_FILE;
@@ -13294,8 +13359,9 @@ int ParseEXRMultipartHeaderFromFile(EXRHeader ***exr_headers, int *num_headers,
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (errcode != 0) {
     tinyexr::SetErrorMessage("Cannot read file " + std::string(filename), err);
     return TINYEXR_ERROR_INVALID_FILE;
@@ -13399,7 +13465,7 @@ int ParseEXRVersionFromFile(EXRVersion *version, const char *filename) {
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
   errno_t err = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (err != 0) {
     // TODO(syoyo): return wfopen_s erro code
@@ -13546,8 +13612,9 @@ int LoadEXRMultipartImageFromFile(EXRImage *exr_images,
 
   FILE *fp = NULL;
 #ifdef _WIN32
-#if defined(_MSC_VER) || defined(__MINGW32__) // MSVC, MinGW gcc or clang
-  errno_t errcode = _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
+#if defined(_MSC_VER) || defined(__MINGW32__)  // MSVC, MinGW gcc or clang
+  errno_t errcode =
+      _wfopen_s(&fp, tinyexr::UTF8ToWchar(filename).c_str(), L"rb");
   if (errcode != 0) {
     tinyexr::SetErrorMessage("Cannot read file " + std::string(filename), err);
     return TINYEXR_ERROR_CANT_OPEN_FILE;


### PR DESCRIPTION
Hello this PR fixes some fuzzing failures we're having over on our side (I'm hoping to fix a few more, please let me know if that would be okay with you)
- added `int*` and `float*` overloads for `swap4` and updated call sites to clean up
- added more checking when `unsigned int` are converted to int
- changed some assertions to normal errors
- fixed compilation warnings in test code
- ran clang-format when I was done which made a bunch of other changes (I can roll those back if you like)