### PR TITLE
Define NOMINMAX in preprocessor

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -559,6 +559,9 @@ extern int LoadEXRFromMemory(float **out_rgba, int *width, int *height,
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>  // for UTF-8
 
 #endif


### PR DESCRIPTION
`<windows.h>` defines `MAX` and `MIN` somewhere, which conflicts with line 10711 in VS 2019 for my case. This can be prevented by defining `NOMINMAX`. 

    if (x_size > static_cast<unsigned int>(std::numeric_limits<int>::max()) ||
        y_size > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
        ...
    }

[Reference](https://stackoverflow.com/a/2789509)

