### PR TITLE
Fix multiple warnings

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -11875,7 +11875,7 @@ static bool isValidTile(const EXRHeader* exr_header,
 
 static void ReconstructTileOffsets(OffsetData& offset_data,
                                    const EXRHeader* exr_header,
-                                   const unsigned char* head, const unsigned char* marker, const size_t size,
+                                   const unsigned char* head, const unsigned char* marker, const size_t /*size*/,
                                    bool isMultiPartFile,
                                    bool isDeep) {
   int numXLevels = offset_data.num_x_levels;
@@ -12044,7 +12044,7 @@ static int DecodeEXRImage(EXRImage *exr_image, const EXRHeader *exr_header,
       PrecalculateTileInfo(num_x_tiles, num_y_tiles, exr_header);
       num_blocks = InitTileOffsets(offset_data, exr_header, num_x_tiles, num_y_tiles);
       if (exr_header->chunk_count > 0) {
-        if (exr_header->chunk_count != num_blocks) {
+        if (exr_header->chunk_count != static_cast<int>(num_blocks)) {
           tinyexr::SetErrorMessage("Invalid offset table size.", err);
           return TINYEXR_ERROR_INVALID_DATA;
         }
@@ -12807,9 +12807,9 @@ static bool EncodePixelData(/* out */ std::vector<unsigned char>& out_data,
                             const unsigned char* const* images,
                             const int* requested_pixel_types,
                             int compression_type,
-                            int line_order,
+                            int /*line_order*/,
                             int width, // for tiled : tile.width
-                            int height, // for tiled : header.tile_size_y
+                            int /*height*/, // for tiled : header.tile_size_y
                             int x_stride, // for tiled : header.tile_size_x
                             int line_no, // for tiled : 0
                             int num_lines, // for tiled : tile.height
@@ -13016,6 +13016,7 @@ static bool EncodePixelData(/* out */ std::vector<unsigned char>& out_data,
     out_data.insert(out_data.end(), block.begin(), block.begin() + data_len);
 
 #else
+    (void)compression_param;
     assert(0);
 #endif
   } else {
@@ -13272,7 +13273,7 @@ static int EncodeChunk(const EXRImage* exr_image, const EXRHeader* exr_header,
         }
       level_image = level_image->next_level;
     }
-    assert(block_idx == num_blocks);
+    assert(static_cast<int>(block_idx) == num_blocks);
     total_size = offset;
   } else { // scanlines
     std::vector<tinyexr::tinyexr_uint64>& offsets = offset_data.offsets[0][0];


### PR DESCRIPTION
This pull requests fixes some warnings that appear with GCC, when `-Wall` is enabled. To remove those, this PR sometimes uses `(void)variable_name` to mark a variable as used, in the case where the variable may be used in an `#ifdef` that is not activated, and sometimes simply comments the name out (like so: `/*variable_name*/`) in order to hide it if it is a parameter that is not used anywhere. For integer comparison warnings, an appropriate cast is added to make sure the two comparands are of the same type.

For reference, here is the warning log before applying this PR:
```
In file included from /home/madmann/Projects/arty2/src/formats/exr.cpp:4:                                                                                                   
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h: In function ‘void tinyexr::ReconstructTileOffsets(tinyexr::OffsetData&, const EXRHeader*, const unsigned char*, cons
t unsigned char*, size_t, bool, bool)’:                                                                                                                                     
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:11878:105: warning: unused parameter ‘size’ [-Wunused-parameter]                                                     
11878 |                                    const unsigned char* head, const unsigned char* marker, const size_t size,                                                       
      |                                                                                            ~~~~~~~~~~~~~^~~~                                                        
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h: In function ‘int tinyexr::DecodeEXRImage(EXRImage*, const EXRHeader*, const unsigned char*, const unsigned char*, si
ze_t, const char**)’:                                                                                                                                                       
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:12047:37: warning: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long uns
igned int’} [-Wsign-compare]
12047 |         if (exr_header->chunk_count != num_blocks) {
      |             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h: In function ‘bool tinyexr::EncodePixelData(std::vector<unsigned char>&, const unsigned char* const*, const int*, int
, int, int, int, int, int, int, size_t, const std::vector<tinyexr::ChannelInfo>&, const std::vector<long unsigned int>&, const void*)’:
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:12810:33: warning: unused parameter ‘line_order’ [-Wunused-parameter]
12810 |                             int line_order,
      |                             ~~~~^~~~~~~~~~
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:12812:33: warning: unused parameter ‘height’ [-Wunused-parameter]
12812 |                             int height, // for tiled : header.tile_size_y
      |                             ~~~~^~~~~~
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:12819:41: warning: unused parameter ‘compression_param’ [-Wunused-parameter]
12819 |                             const void* compression_param = 0) // zfp compression param
      |                             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/10/cassert:44,
                 from /home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:570,
                 from /home/madmann/Projects/arty2/src/formats/exr.cpp:4:
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h: In function ‘int tinyexr::EncodeChunk(const EXRImage*, const EXRHeader*, const std::vector<tinyexr::ChannelInfo>&, i
nt, tinyexr::tinyexr_uint64, bool, tinyexr::OffsetData&, std::vector<std::vector<unsigned char> >&, tinyexr::tinyexr_uint64&, std::string*)’:
/home/madmann/Projects/arty2/contrib/tinyexr/tinyexr.h:13275:22: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and 
‘int’ [-Wsign-compare]
13275 |     assert(block_idx == num_blocks);
      |```