### PR TITLE
Add mention that DWA compression is not planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Current status of `tinyexr` is:
   - [ ] B44?
   - [ ] B44A?
   - [ ] PIX24?
+  - [ ] DWA (not planned, patent encumbered)
 - Line order.
   - [x] Increasing, decreasing (load)
   - [ ] Random?


### PR DESCRIPTION
Stumbled upon the same issue with PolyHaven EXR files in Godot using tinyexr,
which we had discussed here: https://twitter.com/syoyo/status/1255451246586183680

Since I couldn't find any mention to "DWA" in the repo or issues I figured it would be
good to mention it at least once.