### PR TITLE
Fixed problem with channels when specifying no layer name

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -5850,7 +5850,8 @@ static void ChannelsInLayer(const EXRHeader &exr_header,
     if (layer_name.empty()) {
       const size_t pos = ch_name.find_last_of('.');
       if (pos != std::string::npos && pos < ch_name.size()) {
-        continue;
+        if(pos != 0) continue;
+        ch_name = ch_name.substr(pos + 1);
       }
     } else {
       const size_t pos = ch_name.find(layer_name + '.');

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -5850,7 +5850,7 @@ static void ChannelsInLayer(const EXRHeader &exr_header,
     if (layer_name.empty()) {
       const size_t pos = ch_name.find_last_of('.');
       if (pos != std::string::npos && pos < ch_name.size()) {
-        ch_name = ch_name.substr(pos + 1);
+        continue;
       }
     } else {
       const size_t pos = ch_name.find(layer_name + '.');

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -5850,7 +5850,7 @@ static void ChannelsInLayer(const EXRHeader &exr_header,
     if (layer_name.empty()) {
       const size_t pos = ch_name.find_last_of('.');
       if (pos != std::string::npos && pos < ch_name.size()) {
-        if(pos != 0) continue;
+        if (pos != 0) continue;
         ch_name = ch_name.substr(pos + 1);
       }
     } else {


### PR DESCRIPTION
When specifying no layer (`layer_name.empty()`), `ChannelsInLayer `should return only layers without the '.' character.