### PR TITLE
Fix UWP builds

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -608,7 +608,8 @@ extern int LoadEXRFromMemory(float **out_rgba, int *width, int *height,
 #define NOMINMAX
 #endif
 #include <windows.h>  // for UTF-8 and memory-mapping
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+
+#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 #define TINYEXR_USE_WIN32_MMAP (1)
 #endif
 

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -608,7 +608,9 @@ extern int LoadEXRFromMemory(float **out_rgba, int *width, int *height,
 #define NOMINMAX
 #endif
 #include <windows.h>  // for UTF-8 and memory-mapping
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 #define TINYEXR_USE_WIN32_MMAP (1)
+#endif
 
 #elif defined(__linux__) || defined(__unix__)
 #include <fcntl.h>     // for open()


### PR DESCRIPTION
UWP does not support memory mapped files.

Found while updating version in vcpkg: https://github.com/microsoft/vcpkg/pull/32074