### PR TITLE
Remove const from outbuf

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -386,7 +386,7 @@ extern int IsEXRFromMemory(const unsigned char *memory, size_t size);
 // error
 extern int SaveEXRToMemory(const float *data, const int width, const int height,
                    const int components, const int save_as_fp16,
-                   const unsigned char **buffer, const char **err);
+                   unsigned char **buffer, const char **err);
 
 // @deprecated { Not recommended, but handy to use. }
 // Saves single-frame OpenEXR image to a buffer. Assume EXR image contains RGB(A) channels.
@@ -9008,7 +9008,7 @@ int LoadEXRMultipartImageFromFile(EXRImage *exr_images,
 }
 
 int SaveEXRToMemory(const float *data, int width, int height, int components,
-            const int save_as_fp16, const unsigned char **outbuf, const char **err) {
+            const int save_as_fp16, unsigned char **outbuf, const char **err) {
 
   if ((components == 1) || components == 3 || components == 4) {
     // OK


### PR DESCRIPTION
The const marking on outbuf/buffer means that the buffer allocated by SaveEXRToMemory cannot be passed to free without a compiler error.

For example, the following code will not compile because SaveEXRToMemory requires buffer to be const.

```
bool Write(const std::vector<float>& image, std::pair<int, int> size,
           std::ostream& output) {
  const unsigned char* buffer;  // Required to be const by signature of SaveEXRToMemory
  int bytes_written =
      SaveEXRToMemory(image.data(), /*width=*/size.second,
                      /*height=*/size.first, /*components=*/3,
                      /*save_as_fp16=*/1, /*buffer=*/&buffer, /*err=*/nullptr);

  if (bytes_written < 0) {
    return false;
  }

  output.write(reinterpret_cast<const char*>(buffer),
               static_cast<std::streamsize>(bytes_written));

  free(buffer);  // This line triggers a compile error

  return true;
}
```

Unfortunately, this is a breaking API change but since it wasn't possible to call free on the allocated buffer without either a compiler error or a const-cast, I believe this break is a necessary evil.