### PR TITLE
Fix calloc-transposed-args warning

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -4923,7 +4923,7 @@ static int DecodeTiledLevel(EXRImage* exr_image, const EXRHeader* exr_header,
   }
 #endif
   exr_image->tiles = static_cast<EXRTile*>(
-    calloc(sizeof(EXRTile), static_cast<size_t>(num_tiles)));
+    calloc(static_cast<size_t>(num_tiles), sizeof(EXRTile)));
 
 #if TINYEXR_HAS_CXX11 && (TINYEXR_USE_THREAD > 0)
   std::vector<std::thread> workers;


### PR DESCRIPTION
This is a gcc warning: tinyexr.h:4926:12: note: earlier argument should specify number of elements, later size of each element

Simply flipping the arguments fixes the warning