### PR TITLE
CMake: deactivate clang compiler flags for msvc version of clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(${BUILD_TARGET} PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(${BUILD_TARGET} ${TINYEXR_EXT_LIBRARIES} ${CMAKE_DL_LIBS})
 
 # Increase warning level for clang.
-IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MSVC)
   set_source_files_properties(${TINYEXR_SOURCES} PROPERTIES COMPILE_FLAGS "-Weverything -Werror -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
 ENDIF ()
 


### PR DESCRIPTION
See #207