### PR TITLE
Add two missing includes in examples

### DIFF
--- a/examples/exrfilter/exrfilter.cc
+++ b/examples/exrfilter/exrfilter.cc
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <vector>
+#include <iostream>
 
 #include "tinyexr.h"
 

--- a/examples/nornalmap/main.cc
+++ b/examples/nornalmap/main.cc
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #define TINYEXR_IMPLEMENTATION
 #include "tinyexr.h"
 


### PR DESCRIPTION
std::cout is undefined on linux otherwise (clang-19/gcc-14 libcxx)