### PR TITLE
Add Compression HTJ2K, ZSTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Current status of `tinyexr` is:
   - [x] ZFP (tinyexr extension)
   - [x] B44/B44A (OpenEXR compatible)
   - [x] PXR24 (OpenEXR compatible)
+  - [ ] HTJ2K
+  - [ ] ZSTD
   - [ ] DWA (not planned, patent encumbered)
 - Spectral EXR (JCGT 2021)
   - [x] Emissive spectra (S{n}.{wavelength}nm)

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -217,6 +217,9 @@ extern "C" {
 #define TINYEXR_COMPRESSIONTYPE_B44A (7)
 #define TINYEXR_COMPRESSIONTYPE_DWAA (8)   // Not yet supported
 #define TINYEXR_COMPRESSIONTYPE_DWAB (9)   // Not yet supported
+#define TINYEXR_COMPRESSIONTYPE_HTJ2K256 (10)   // Not yet supported
+#define TINYEXR_COMPRESSIONTYPE_HTJ2K32 (11)   // Not yet supported
+#define TINYEXR_COMPRESSIONTYPE_ZSTD (12)   // Not yet supported
 #define TINYEXR_COMPRESSIONTYPE_ZFP (128)  // TinyEXR extension
 
 #define TINYEXR_ZFP_COMPRESSIONTYPE_RATE (0)

--- a/tinyexr_v2_impl.hh
+++ b/tinyexr_v2_impl.hh
@@ -110,6 +110,9 @@ enum CompressionType {
   COMPRESSION_B44A = 7,
   COMPRESSION_DWAA = 8,
   COMPRESSION_DWAB = 9
+  COMPRESSION_HTJ2K256 = 10
+  COMPRESSION_HTJ2K32 = 11
+  COMPRESSION_ZSTD = 12
 };
 
 // Pixel types
@@ -1060,6 +1063,11 @@ static int GetScanlinesPerBlock(int compression) {
       return 32;
     case COMPRESSION_DWAB:
       return 256;
+    case COMPRESSION_HTJ2K256:
+      return 256;
+    case COMPRESSION_HTJ2K32:
+      return 32;
+    case COMPRESSION_ZSTD:
     default:
       return 1;
   }


### PR DESCRIPTION
- Add OpenEXR file format for lossless or lossy compression with **High Throughput JPEG-2000 (HTJ2K)**
- Add OpenEXR file format for lossless compression with **Zstandard**