### PR TITLE
Fix unchecked malloc return values that can cause NULL pointer dereferences

### DIFF
--- a/test/issues/test_malloc_failure.cpp
+++ b/test/issues/test_malloc_failure.cpp
@@ -1,0 +1,66 @@
+// Test malloc failure handling - verifies no crashes on allocation failure
+// Build: g++ -std=c++17 test_malloc_failure.cpp -lz -o test && ./test
+#include <cstdio>
+#include <cstdlib>
+#include <signal.h>
+#include <setjmp.h>
+
+static int g_fail_at = -1, g_count = 0;
+static sigjmp_buf g_jmp;
+
+// Signal handler - jump back to test loop on crash
+static void on_crash(int sig) { siglongjmp(g_jmp, sig); }
+
+// Fake allocators - return NULL at g_fail_at'th call
+static void* fake_malloc(size_t sz) { return (++g_count == g_fail_at) ? NULL : malloc(sz); }
+static void* fake_realloc(void* p, size_t sz) { return (++g_count == g_fail_at) ? NULL : realloc(p, sz); }
+static void* fake_calloc(size_t n, size_t sz) { return (++g_count == g_fail_at) ? NULL : calloc(n, sz); }
+
+// Intercept allocators before including tinyexr
+#define malloc fake_malloc
+#define realloc fake_realloc
+#define calloc fake_calloc
+
+#define TINYEXR_IMPLEMENTATION
+#define TINYEXR_USE_MINIZ 0
+#include <zlib.h>
+#include "../../tinyexr.h"
+
+int main() {
+    float pixels[64] = {0};
+    int crashes = 0;
+
+    // Baseline run - count mallocs with no failures
+    g_fail_at = -1;
+    g_count = 0;
+    unsigned char* out = NULL;
+    const char* err = NULL;
+    SaveEXRToMemory(pixels, 4, 4, 4, 0, &out, &err);
+    if (out) free(out);
+    if (err) FreeEXRErrorMessage(err);
+    int num_mallocs = g_count;
+
+    printf("Testing %d mallocs:\n", num_mallocs);
+
+    // Test each malloc failure point
+    for (int i = 1; i <= num_mallocs; i++) {
+        g_fail_at = i;
+        g_count = 0;
+        out = NULL;
+        err = NULL;
+
+        signal(SIGSEGV, on_crash);           // Re-register handler each iteration
+        if (sigsetjmp(g_jmp, 1) == 0) {      // Returns 0 on first call
+            int ret = SaveEXRToMemory(pixels, 4, 4, 4, 0, &out, &err);
+            printf("  #%d: ret=%d %s\n", i, ret, err ? err : "");
+            if (out) free(out);
+            if (err) FreeEXRErrorMessage(err);
+        } else {                             // Returns sig after siglongjmp from crash
+            printf("  #%d: CRASH\n", i);
+            crashes++;
+        }
+    }
+
+    printf(crashes ? "FAILED: %d crashes\n" : "PASSED\n", crashes);
+    return crashes;
+}

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -9447,6 +9447,10 @@ static size_t SaveEXRNPartImageToMemory(const EXRImage* exr_images,
     return TINYEXR_ERROR_INVALID_DATA;
   }
   (*memory_out) = static_cast<unsigned char*>(malloc(size_t(total_size)));
+  if (!(*memory_out)) {
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return 0;
+  }
 
   // Writing header
   memcpy((*memory_out), &memory[0], memory.size());

--- a/tinyexr.h
+++ b/tinyexr.h
@@ -196,6 +196,7 @@ extern "C" {
 #define TINYEXR_ERROR_SERIALIZATION_FAILED (-12)
 #define TINYEXR_ERROR_LAYER_NOT_FOUND (-13)
 #define TINYEXR_ERROR_DATA_TOO_LARGE (-14)
+#define TINYEXR_ERROR_OUT_OF_MEMORY (-15)
 
 // @note { OpenEXR file format: http://www.openexr.com/openexrfilelayout.pdf }
 
@@ -5724,6 +5725,10 @@ static unsigned char **AllocateImage(int num_channels,
   unsigned char **images =
       reinterpret_cast<unsigned char **>(static_cast<float **>(
           malloc(sizeof(float *) * static_cast<size_t>(num_channels))));
+  if (!images) {
+    if (success) *success = false;
+    return NULL;
+  }
 
   for (size_t c = 0; c < static_cast<size_t>(num_channels); c++) {
     images[c] = NULL;
@@ -6230,6 +6235,10 @@ static bool ConvertHeader(EXRHeader *exr_header, const HeaderInfo &info, std::st
 
   exr_header->channels = static_cast<EXRChannelInfo *>(malloc(
       sizeof(EXRChannelInfo) * static_cast<size_t>(exr_header->num_channels)));
+  if (!exr_header->channels) {
+    if (err) (*err) += "Out of memory.\n";
+    return false;
+  }
   for (size_t c = 0; c < static_cast<size_t>(exr_header->num_channels); c++) {
 #ifdef _MSC_VER
     strncpy_s(exr_header->channels[c].name, info.channels[c].name.c_str(), 255);
@@ -6247,6 +6256,11 @@ static bool ConvertHeader(EXRHeader *exr_header, const HeaderInfo &info, std::st
 
   exr_header->pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(exr_header->num_channels)));
+  if (!exr_header->pixel_types) {
+    free(exr_header->channels);
+    if (err) (*err) += "Out of memory.\n";
+    return false;
+  }
   for (size_t c = 0; c < static_cast<size_t>(exr_header->num_channels); c++) {
     exr_header->pixel_types[c] = info.channels[c].pixel_type;
   }
@@ -6254,6 +6268,12 @@ static bool ConvertHeader(EXRHeader *exr_header, const HeaderInfo &info, std::st
   // Initially fill with values of `pixel_types`
   exr_header->requested_pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(exr_header->num_channels)));
+  if (!exr_header->requested_pixel_types) {
+    free(exr_header->channels);
+    free(exr_header->pixel_types);
+    if (err) (*err) += "Out of memory.\n";
+    return false;
+  }
   for (size_t c = 0; c < static_cast<size_t>(exr_header->num_channels); c++) {
     exr_header->requested_pixel_types[c] = info.channels[c].pixel_type;
   }
@@ -6269,6 +6289,13 @@ static bool ConvertHeader(EXRHeader *exr_header, const HeaderInfo &info, std::st
 
     exr_header->custom_attributes = static_cast<EXRAttribute *>(malloc(
         sizeof(EXRAttribute) * size_t(exr_header->num_custom_attributes)));
+    if (!exr_header->custom_attributes) {
+      free(exr_header->channels);
+      free(exr_header->pixel_types);
+      free(exr_header->requested_pixel_types);
+      if (err) (*err) += "Out of memory.\n";
+      return false;
+    }
 
     for (size_t i = 0; i < size_t(exr_header->num_custom_attributes); i++) {
       memcpy(exr_header->custom_attributes[i].name, info.attributes[i].name,
@@ -10219,12 +10246,24 @@ int ParseEXRMultipartHeaderFromMemory(EXRHeader ***exr_headers,
   // allocate memory for EXRHeader and create array of EXRHeader pointers.
   (*exr_headers) =
       static_cast<EXRHeader **>(malloc(sizeof(EXRHeader *) * infos.size()));
-
+  if (!(*exr_headers)) {
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
 
   int retcode = TINYEXR_SUCCESS;
 
   for (size_t i = 0; i < infos.size(); i++) {
     EXRHeader *exr_header = static_cast<EXRHeader *>(malloc(sizeof(EXRHeader)));
+    if (!exr_header) {
+      for (size_t j = 0; j < i; j++) {
+        FreeEXRHeader((*exr_headers)[j]);
+        free((*exr_headers)[j]);
+      }
+      free(*exr_headers);
+      tinyexr::SetErrorMessage("Out of memory.", err);
+      return TINYEXR_ERROR_OUT_OF_MEMORY;
+    }
     memset(exr_header, 0, sizeof(EXRHeader));
 
     std::string warn;
@@ -10627,6 +10666,10 @@ int SaveEXRToMemory(const float *data, int width, int height, int components,
   header.num_channels = components;
   header.channels = static_cast<EXRChannelInfo *>(malloc(
       sizeof(EXRChannelInfo) * static_cast<size_t>(header.num_channels)));
+  if (!header.channels) {
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   // Must be (A)BGR order, since most of EXR viewers expect this channel order.
   if (components == 4) {
 #ifdef _MSC_VER
@@ -10668,8 +10711,19 @@ int SaveEXRToMemory(const float *data, int width, int height, int components,
 
   header.pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
+  if (!header.pixel_types) {
+    free(header.channels);
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   header.requested_pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
+  if (!header.requested_pixel_types) {
+    free(header.channels);
+    free(header.pixel_types);
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   for (int i = 0; i < header.num_channels; i++) {
     header.pixel_types[i] =
         TINYEXR_PIXELTYPE_FLOAT;  // pixel type of input image
@@ -10689,6 +10743,9 @@ int SaveEXRToMemory(const float *data, int width, int height, int components,
   size_t mem_size = SaveEXRImageToMemory(&image, &header, &mem_buf, err);
 
   if (mem_size == 0) {
+    free(header.channels);
+    free(header.pixel_types);
+    free(header.requested_pixel_types);
     return TINYEXR_ERROR_SERIALIZATION_FAILED;
   }
 
@@ -10784,6 +10841,10 @@ int SaveEXR(const float *data, int width, int height, int components,
   header.num_channels = components;
   header.channels = static_cast<EXRChannelInfo *>(malloc(
       sizeof(EXRChannelInfo) * static_cast<size_t>(header.num_channels)));
+  if (!header.channels) {
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   // Must be (A)BGR order, since most of EXR viewers expect this channel order.
   if (components == 4) {
 #ifdef _MSC_VER
@@ -10825,8 +10886,19 @@ int SaveEXR(const float *data, int width, int height, int components,
 
   header.pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
+  if (!header.pixel_types) {
+    free(header.channels);
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   header.requested_pixel_types = static_cast<int *>(
       malloc(sizeof(int) * static_cast<size_t>(header.num_channels)));
+  if (!header.requested_pixel_types) {
+    free(header.channels);
+    free(header.pixel_types);
+    tinyexr::SetErrorMessage("Out of memory.", err);
+    return TINYEXR_ERROR_OUT_OF_MEMORY;
+  }
   for (int i = 0; i < header.num_channels; i++) {
     header.pixel_types[i] =
         TINYEXR_PIXELTYPE_FLOAT;  // pixel type of input image


### PR DESCRIPTION
## Summary

- Add NULL checks after `malloc()` calls that were missing error handling
- On allocation failure, functions now return appropriate error codes instead of dereferencing NULL pointers
- Add new `TINYEXR_ERROR_OUT_OF_MEMORY` (-15) error code

## Changes

| Function | Allocations Fixed |
|----------|-------------------|
| `AllocateImage` | `images` |
| `ConvertHeader` | `channels`, `pixel_types`, `requested_pixel_types`, `custom_attributes` |
| `ParseEXRMultipartHeaderFromMemory` | `exr_headers`, `exr_header` |
| `SaveEXRToMemory` | `header.channels`, `header.pixel_types`, `header.requested_pixel_types` |
| `SaveEXR` | `header.channels`, `header.pixel_types`, `header.requested_pixel_types` |

## Example

```cpp
// Before:
EXRHeader *exr_header = static_cast<EXRHeader *>(malloc(sizeof(EXRHeader)));
memset(exr_header, 0, sizeof(EXRHeader));  // CRASH if malloc returned NULL

// After:
EXRHeader *exr_header = static_cast<EXRHeader *>(malloc(sizeof(EXRHeader)));
if (!exr_header) {
  tinyexr::SetErrorMessage("Out of memory.", err);
  return TINYEXR_ERROR_OUT_OF_MEMORY;
}
memset(exr_header, 0, sizeof(EXRHeader));
```

## Test Plan

- [x] Code compiles without warnings
- [ ] Tested with memory allocation failures (optional)