### PR TITLE
Fix double-free in FreeEXRImage when DecodeChunk fails

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -10097,6 +10097,7 @@ int FreeEXRImage(EXRImage *exr_image) {
   if (exr_image->next_level) {
     FreeEXRImage(exr_image->next_level);
     delete exr_image->next_level;
+    exr_image->next_level = NULL;
   }
 
   for (int i = 0; i < exr_image->num_channels; i++) {
@@ -10107,6 +10108,7 @@ int FreeEXRImage(EXRImage *exr_image) {
 
   if (exr_image->images) {
     free(exr_image->images);
+    exr_image->images = NULL;
   }
 
   if (exr_image->tiles) {
@@ -10121,7 +10123,11 @@ int FreeEXRImage(EXRImage *exr_image) {
       }
     }
     free(exr_image->tiles);
+    exr_image->tiles = NULL;
   }
+
+  exr_image->num_channels = 0;
+  exr_image->num_tiles = 0;
 
   return TINYEXR_SUCCESS;
 }


### PR DESCRIPTION
When `DecodeChunk()` fails inside `DecodeEXRImage()`, `FreeEXRImage()` is called to clean up (line 7532). But the freed pointers (`images`, `tiles`, etc.) are not set to NULL. The caller then calls `FreeEXRImage()` again on the same struct, causing a double-free.

This affects `LoadEXRFromMemory()`, `LoadEXRImageFromMemory()`, and the multipart variants.

**Fix:** NULL out pointers in `FreeEXRImage()` after freeing, and reset `num_channels`/`num_tiles` to 0.

**Reproducer:** https://gist.github.com/segv0x/af60b3396636319d1af9923030ae8955

```
ERROR: AddressSanitizer: attempting double-free
    #0 free
    #1 FreeEXRImage             tinyexr.h:10109
    #2 LoadEXRFromMemory        tinyexr.h:8025
```