### PR TITLE
Fix heap-buffer-overflow in B44 DecodePixelData with mixed channel types

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -5432,9 +5432,9 @@ static bool DecodePixelData(/* out */ unsigned char **out_images,
     }
 
     // Process decompressed data - B44 returns data organized per channel
+    size_t ch_offset = 0;
     for (size_t c = 0; c < static_cast<size_t>(num_channels); c++) {
-      size_t ch_offset = c * static_cast<size_t>(width) * num_lines *
-                         ((channels[c].pixel_type == TINYEXR_PIXELTYPE_HALF) ? 2 : 4);
+      size_t ch_bytes = (channels[c].pixel_type == TINYEXR_PIXELTYPE_HALF) ? 2 : 4;
 
       if (channels[c].pixel_type == TINYEXR_PIXELTYPE_HALF) {
         for (size_t v = 0; v < static_cast<size_t>(num_lines); v++) {
@@ -5526,6 +5526,8 @@ static bool DecodePixelData(/* out */ unsigned char **out_images,
       } else {
         return false;
       }
+
+      ch_offset += static_cast<size_t>(width) * static_cast<size_t>(num_lines) * ch_bytes;
     }
   } else if (compression_type == TINYEXR_COMPRESSIONTYPE_NONE) {
     for (size_t c = 0; c < num_channels; c++) {


### PR DESCRIPTION
In the B44 decompression path of `DecodePixelData()`, the per-channel buffer offset is calculated as:

```c
size_t ch_offset = c * width * num_lines * ((channels[c].pixel_type == HALF) ? 2 : 4);
```

This assumes all channels have the same byte width. With mixed types (e.g. HALF + FLOAT), the offset for later channels overshoots the buffer, causing an out-of-bounds read.

**Fix:** accumulate preceding channel sizes instead of multiplying by channel index.

```c
size_t ch_offset = 0;
for (size_t c = 0; c < num_channels; c++) {
    size_t ch_bytes = (channels[c].pixel_type == HALF) ? 2 : 4;
    // ... process channel c at ch_offset ...
    ch_offset += width * num_lines * ch_bytes;
}
```

**Reproducer:** https://gist.github.com/segv0x/d132be4d6daad615577ea2a467735faf

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x...
READ of size 1
    #0 tinyexr::cpy4()            tinyexr.h:938
    #1 tinyexr::DecodePixelData()  tinyexr.h:5510
```