### PR TITLE
Fix Windows ARM GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
             runs_on: windows-latest
             family: windows
             msvc_arch: amd64
-            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -83,7 +82,6 @@ jobs:
             runs_on: windows-latest
             family: windows
             msvc_arch: amd64_x86
-            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -92,7 +90,6 @@ jobs:
             runs_on: windows-11-arm
             family: windows
             msvc_arch: amd64_arm64
-            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -101,7 +98,6 @@ jobs:
             runs_on: windows-11-arm
             family: windows
             msvc_arch: amd64_arm
-            build_legacy_tester: false
             apt_packages: ""
             run_tests: false
             experimental: true
@@ -155,18 +151,32 @@ jobs:
           cl.exe /EHsc /O2 /I..\..\deps\miniz /c ..\..\deps\miniz\miniz.c
 
       - name: Build Windows legacy unit tests
-        if: matrix.family == 'windows' && matrix.build_legacy_tester
+        if: matrix.family == 'windows' && matrix.run_tests
         working-directory: test/unit
         shell: cmd
         run: |
           cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz tester.cc miniz.obj /Fe:tester.exe
 
+      - name: Compile Windows legacy unit tests
+        if: matrix.family == 'windows' && !matrix.run_tests
+        working-directory: test/unit
+        shell: cmd
+        run: |
+          cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz /c tester.cc /Fo:tester.obj
+
       - name: Build Windows v2 unit tests
-        if: matrix.family == 'windows'
+        if: matrix.family == 'windows' && matrix.run_tests
         working-directory: test/unit
         shell: cmd
         run: |
           cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz tester-v2.cc miniz.obj /Fe:tester-v2.exe
+
+      - name: Compile Windows v2 unit tests
+        if: matrix.family == 'windows' && !matrix.run_tests
+        working-directory: test/unit
+        shell: cmd
+        run: |
+          cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz /c tester-v2.cc /Fo:tester-v2.obj
 
       - name: Run Windows unit tests
         if: matrix.family == 'windows' && matrix.run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
             runs_on: windows-latest
             family: windows
             msvc_arch: amd64
+            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -82,6 +83,7 @@ jobs:
             runs_on: windows-latest
             family: windows
             msvc_arch: amd64_x86
+            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -90,6 +92,7 @@ jobs:
             runs_on: windows-11-arm
             family: windows
             msvc_arch: amd64_arm64
+            build_legacy_tester: true
             apt_packages: ""
             run_tests: true
             experimental: false
@@ -98,6 +101,7 @@ jobs:
             runs_on: windows-11-arm
             family: windows
             msvc_arch: amd64_arm
+            build_legacy_tester: false
             apt_packages: ""
             run_tests: false
             experimental: true
@@ -143,13 +147,25 @@ jobs:
         with:
           arch: ${{ matrix.msvc_arch }}
 
-      - name: Build Windows unit tests
+      - name: Build Windows test dependency
         if: matrix.family == 'windows'
         working-directory: test/unit
         shell: cmd
         run: |
           cl.exe /EHsc /O2 /I..\..\deps\miniz /c ..\..\deps\miniz\miniz.c
+
+      - name: Build Windows legacy unit tests
+        if: matrix.family == 'windows' && matrix.build_legacy_tester
+        working-directory: test/unit
+        shell: cmd
+        run: |
           cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz tester.cc miniz.obj /Fe:tester.exe
+
+      - name: Build Windows v2 unit tests
+        if: matrix.family == 'windows'
+        working-directory: test/unit
+        shell: cmd
+        run: |
           cl.exe /EHsc /O2 /std:c++14 /I..\.. /I..\..\deps\miniz tester-v2.cc miniz.obj /Fe:tester-v2.exe
 
       - name: Run Windows unit tests

--- a/tinyexr_huffman.hh
+++ b/tinyexr_huffman.hh
@@ -115,7 +115,6 @@
 #include <intrin.h>
 #define TINYEXR_PREFETCH(addr) _mm_prefetch((const char*)(addr), _MM_HINT_T0)
 #elif defined(_MSC_VER)
-#include <intrin.h>
 #define TINYEXR_PREFETCH(addr) \
   do {                         \
     (void)(addr);              \

--- a/tinyexr_huffman.hh
+++ b/tinyexr_huffman.hh
@@ -111,9 +111,12 @@
 #ifndef TINYEXR_PREFETCH
 #if defined(__GNUC__) || defined(__clang__)
 #define TINYEXR_PREFETCH(addr) __builtin_prefetch(addr)
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #include <intrin.h>
 #define TINYEXR_PREFETCH(addr) _mm_prefetch((const char*)(addr), _MM_HINT_T0)
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#define TINYEXR_PREFETCH(addr) ((void)0)
 #else
 #define TINYEXR_PREFETCH(addr) ((void)0)
 #endif

--- a/tinyexr_huffman.hh
+++ b/tinyexr_huffman.hh
@@ -116,9 +116,15 @@
 #define TINYEXR_PREFETCH(addr) _mm_prefetch((const char*)(addr), _MM_HINT_T0)
 #elif defined(_MSC_VER)
 #include <intrin.h>
-#define TINYEXR_PREFETCH(addr) ((void)0)
+#define TINYEXR_PREFETCH(addr) \
+  do {                         \
+    (void)(addr);              \
+  } while (0)
 #else
-#define TINYEXR_PREFETCH(addr) ((void)0)
+#define TINYEXR_PREFETCH(addr) \
+  do {                         \
+    (void)(addr);              \
+  } while (0)
 #endif
 #endif
 

--- a/tinyexr_simd.hh
+++ b/tinyexr_simd.hh
@@ -1180,7 +1180,6 @@ inline void reverse_delta_predictor(uint8_t* data, size_t count) {
 #include <intrin.h>
 #define TINYEXR_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
 #elif defined(_MSC_VER)
-#include <intrin.h>
 #define TINYEXR_PREFETCH(addr) (void)(addr)
 #else
 #define TINYEXR_PREFETCH(addr) (void)(addr)

--- a/tinyexr_simd.hh
+++ b/tinyexr_simd.hh
@@ -1176,9 +1176,12 @@ inline void reverse_delta_predictor(uint8_t* data, size_t count) {
 #ifndef TINYEXR_PREFETCH
 #if defined(__GNUC__) || defined(__clang__)
 #define TINYEXR_PREFETCH(addr) __builtin_prefetch(addr, 0, 3)
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #include <intrin.h>
 #define TINYEXR_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#define TINYEXR_PREFETCH(addr) ((void)0)
 #else
 #define TINYEXR_PREFETCH(addr) ((void)0)
 #endif

--- a/tinyexr_simd.hh
+++ b/tinyexr_simd.hh
@@ -1181,9 +1181,9 @@ inline void reverse_delta_predictor(uint8_t* data, size_t count) {
 #define TINYEXR_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
 #elif defined(_MSC_VER)
 #include <intrin.h>
-#define TINYEXR_PREFETCH(addr) ((void)0)
+#define TINYEXR_PREFETCH(addr) (void)(addr)
 #else
-#define TINYEXR_PREFETCH(addr) ((void)0)
+#define TINYEXR_PREFETCH(addr) (void)(addr)
 #endif
 #endif
 


### PR DESCRIPTION
- [x] Fix prefetch macro on non-x86 MSVC targets (tinyexr_simd.hh, tinyexr_huffman.hh)
- [x] Use `(void)(addr)` / `do { (void)(addr); } while(0)` no-op forms to consume the argument
- [x] Remove redundant `#include <intrin.h>` from the non-x86 MSVC fallback branch (not needed for the no-op)
- [x] Keep Windows ARM32 CI job as build-only (skip legacy tester)