### PR TITLE
Fix typo in ParseEXRHeaderFromMemory doc comment - "Meomory" to "Memory"

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -323,7 +323,7 @@ typedef struct TEXRHeader {
 
   int compression_type;        // compression type(TINYEXR_COMPRESSIONTYPE_*)
   int *requested_pixel_types;  // Filled initially by
-                               // ParseEXRHeaderFrom(Meomory|File), then users
+                               // ParseEXRHeaderFrom(Memory|File), then users
                                // can edit it(only valid for HALF pixel type
                                // channel)
   // name attribute required for multipart files;


### PR DESCRIPTION
### Description

Corrects a typo in the `ParseEXRHeaderFromMemory` / `ParseEXRHeaderFromFile` documentation block inside `tinyexr.h`, within the TEXRHeader struct for the `name` property.

* **Changes:** Fixes `Meomory` to `Memory`.

No code, logic, or whitespace formatting changes were made.