### PR TITLE
Decode perf: PIZ speedup + runtime zlib backend (libdeflate default on hosted)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MINIZ_SRC = ./deps/miniz/miniz.c
 # ---- legacy v1 single-header test (unchanged) -----------------------------
 TARGET = test_tinyexr
 
-.PHONY: all test clean help lib test-c test-c-threads test-c-tsan c11-gate fuzz-corpus fuzz-corpus-asan parse-test wasm freestanding-gate examples-c bench bench-compare arm-smoke host-smoke gpu-test vk-test jph-gpu-test bench-gpu-jph
+.PHONY: all test clean help lib test-c test-c-threads test-c-tsan c11-gate fuzz fuzz-jph fuzz-libdeflate fuzz-corpus fuzz-corpus-asan parse-test wasm freestanding-gate examples-c bench bench-compare arm-smoke host-smoke gpu-test vk-test jph-gpu-test bench-gpu-jph
 
 all: $(TARGET)
 
@@ -49,15 +49,27 @@ ZSTD_OBJ = build/tinyexr_zstd.o
 V3_TEST_OBJ = $(patsubst src/%.c,build/test-%.o,$(V3_SRC))
 SAN      = -fsanitize=address,undefined
 
-# ---- optional libdeflate backend (default OFF; in-tree codec is the default)
-# Build any target with LIBDEFLATE=1 to route ZIP/ZIPS/PXR24 deflate through the
-# vendored libdeflate (deps/libdeflate, MIT - see deps/libdeflate/COPYING).
-# NOTE: run `make clean` when toggling LIBDEFLATE (object flags are not tracked).
-LIBDEFLATE ?= 0
+# ---- zlib (DEFLATE) backend for ZIP/ZIPS/PXR24 ----------------------------
+# DEFLATE = auto | libdeflate | intree    (default: auto)
+#   auto / libdeflate : compile the vendored libdeflate (deps/libdeflate, MIT -
+#                       see deps/libdeflate/COPYING) AND make it the runtime
+#                       default - it is faster on natural-image data. Both
+#                       codecs are linked; switch at runtime with the public
+#                       exr_zlib_set_backend(). EXR_ZLIB_DEFAULT_LIBDEFLATE=1
+#                       seeds the static default (see src/exr_codec.c).
+#   intree            : in-tree pure-C codec only, no external dependency.
+# The freestanding and wasm targets never define EXR_USE_LIBDEFLATE (their flag
+# sets / V3_CORE_SRC omit it), so they always use the in-tree codec regardless.
+# Legacy: LIBDEFLATE=1 is kept as an alias for DEFLATE=libdeflate.
+# NOTE: run `make clean` when changing DEFLATE (object flags are not tracked).
+DEFLATE ?= auto
+ifeq ($(LIBDEFLATE),1)
+  DEFLATE = libdeflate
+endif
 LD_OBJ =
 LD_TEST_OBJ =
-ifeq ($(LIBDEFLATE),1)
-  V3_DEFS += -DEXR_USE_LIBDEFLATE
+ifneq ($(DEFLATE),intree)
+  V3_DEFS += -DEXR_USE_LIBDEFLATE -DEXR_ZLIB_DEFAULT_LIBDEFLATE=1
   V3_INC  += -Ideps/libdeflate
   # Just the zlib (DEFLATE) path: no crc32/gzip. The x86/arm cpu_features files
   # self-guard by arch, so compiling both is safe everywhere.
@@ -277,6 +289,19 @@ fuzz: test/fuzzer/fuzz_v3.c | build
 	clang $(V3_CSTD) $(V3_INC) -O1 -g -w -fsanitize=fuzzer,address,undefined \
 	  test/fuzzer/fuzz_v3.c $(V3_SRC) $(ZSTD_SRC) -lm -o build/fuzz_v3
 	@echo "built build/fuzz_v3 - e.g. ./build/fuzz_v3 -max_total_time=60 test/unit/regression"
+
+# Same fuzzer but with libdeflate as the default zlib backend, so the shipped
+# DEFLATE=auto decode path (ZIP/ZIPS/PXR24 -> libdeflate) is fuzzed too.
+fuzz-libdeflate: test/fuzzer/fuzz_v3.c | build
+	clang $(V3_CSTD) -DEXR_USE_LIBDEFLATE -DEXR_ZLIB_DEFAULT_LIBDEFLATE=1 \
+	  $(V3_INC) -Ideps/libdeflate -O1 -g -w -fsanitize=fuzzer,address,undefined \
+	  test/fuzzer/fuzz_v3.c $(V3_SRC) $(ZSTD_SRC) \
+	  deps/libdeflate/lib/adler32.c deps/libdeflate/lib/deflate_compress.c \
+	  deps/libdeflate/lib/deflate_decompress.c deps/libdeflate/lib/zlib_compress.c \
+	  deps/libdeflate/lib/zlib_decompress.c deps/libdeflate/lib/utils.c \
+	  deps/libdeflate/lib/x86/cpu_features.c deps/libdeflate/lib/arm/cpu_features.c \
+	  -lm -o build/fuzz_v3_libdeflate
+	@echo "built build/fuzz_v3_libdeflate (libdeflate default backend)"
 
 # HTJ2K (JPH) encode+decode+round-trip fuzzer.
 #   ./build/fuzz_jph -max_total_time=600 test/fuzzer/corpus_jph
@@ -542,8 +567,10 @@ help:
 	@echo "make arm-smoke - cross-build (aarch64) + run NEON SIMD smoke under qemu"
 	@echo "make host-smoke - build + run the SIMD smoke test natively"
 	@echo ""
-	@echo "Add LIBDEFLATE=1 to any target to use the optional vendored libdeflate"
-	@echo "  backend for ZIP/ZIPS/PXR24 (default: in-tree codec). Run 'make clean'"
-	@echo "  when toggling. e.g. make bench-compare LIBDEFLATE=1"
+	@echo "DEFLATE=auto|libdeflate|intree selects the ZIP/ZIPS/PXR24 zlib backend"
+	@echo "  (default: auto = vendored libdeflate, faster on natural images; both"
+	@echo "  codecs link, switch at runtime via exr_zlib_set_backend). intree =="
+	@echo "  in-tree pure-C only. Run 'make clean' when changing. LIBDEFLATE=1 is a"
+	@echo "  legacy alias for DEFLATE=libdeflate. freestanding/wasm stay in-tree."
 	@echo "Add THREADS=1 to any target for C11-threads parallel encode/decode"
 	@echo "  (default: single-threaded). Set count via exr_set_num_threads()."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ embed into your application. It comes in two flavours:
 > live, editable OCIO config that **JIT-compiles to a GLSL shader**. See [tocio](#tocio--tiny-pure-c11-opencolorio-engine) below.
 
 **Performance (v3) at a glance** — single-thread decode/encode vs the reference
-OpenEXR library, with the optional **libdeflate** backend on/off (and HTJ2K,
+OpenEXR library, with the vendored **libdeflate** backend on/off (and HTJ2K,
 which has no deflate path). With the same backend TinyEXR meets or beats OpenEXR
 on the deflate family:
 
@@ -60,7 +60,7 @@ codec-by-codec and multi-threaded numbers.
 | WASM | ✅ core + browser viewer | loader only (experimental/js) |
 | SIMD | SSE2 / SSE4.1 / AVX2 / F16C / NEON | — |
 | Threading | C11 threads (opt-in) | C++11 thread / OpenMP |
-| Dependencies | none in core (optional zstd / libdeflate) | miniz (bundled) + optional zfp |
+| Dependencies | none in core; vendored zstd + libdeflate (libdeflate default on hosted, dropped in freestanding/WASM) | miniz (bundled) + optional zfp |
 
 ---
 
@@ -87,6 +87,12 @@ Build: `make lib` (`build/libtinyexr3.a`), `make test-c`, `make c11-gate`.
 Unit tests live in `test/unit/test_exr_v3.c` (run under ASan/UBSan via `make
 test-c`); `make fuzz-corpus` replays the fuzzer corpus.
 
+The zlib backend for ZIP/ZIPS/PXR24 is selected with `DEFLATE=auto|libdeflate|intree`
+(default `auto` → vendored **libdeflate**, faster on natural-image data). `intree`
+builds the dependency-free pure-C codec only; freestanding and WASM builds always
+use it. Both codecs link under `auto`, so you can switch at runtime with
+`exr_zlib_set_backend()` (e.g. for testing or to honor a custom allocator).
+
 ## Performance vs OpenEXR
 
 Benchmarked against the reference **OpenEXR** library (4.0-dev) on an idle AMD
@@ -94,16 +100,17 @@ Ryzen 9 3950X (Zen2), `asakusa.exr` 660×440, fully in-memory, both pinned to th
 same thread count. Throughput in megapixels/s. Full writeup + charts:
 [`doc/performance-vs-openexr.md`](doc/performance-vs-openexr.md).
 
-- **Single thread, default (dependency-free) decode:** TinyEXR is faster on the
-  cheap codecs — **uncompressed ~3.4×** (2699 vs 789) and **RLE ~2.5×**
-  (230 vs 93). OpenEXR leads the compressed codecs (ZIP ~1.2×, PXR24 ~1.8×,
-  ZIPS ~2.1×, PIZ ~2.7×, HTJ2K ~2.5–3×), thanks to its libdeflate / tuned
-  PIZ / OpenJPH backends.
+- **Single thread, dependency-free decode** (`DEFLATE=intree`): TinyEXR is faster
+  on the cheap codecs — **uncompressed ~3.4×** (2699 vs 789) and **RLE ~2.5×**
+  (230 vs 93). With the pure-C deflate codec OpenEXR leads the compressed family
+  (ZIP ~1.2×, PXR24 ~1.8×, ZIPS ~2.1×, PIZ ~2.7×, HTJ2K ~2.5–3×), thanks to its
+  libdeflate / tuned PIZ / OpenJPH backends.
 - **Single-thread encode:** ties/wins on RLE/PIZ/B44; OpenEXR is ~1.5× on
   ZIP/ZIPS, ~1.8× on PXR24, ~4× on HTJ2K.
-- **Optional libdeflate backend** (`make … LIBDEFLATE=1`, off by default): with
-  the same backend TinyEXR **matches or beats** OpenEXR on the deflate family —
-  e.g. ZIP decode **1.37×** (80.8 vs 58.8), sizes byte-identical.
+- **Default decode uses libdeflate** (`DEFLATE=auto`): with the same backend
+  TinyEXR **matches or beats** OpenEXR on the deflate family — ZIP decode
+  **1.37×** (80.8 vs 58.8), sizes byte-identical. On a broad natural-image corpus
+  this is a large lift over the in-tree codec (ZIP ~+73%, ZIPS ~+63%, PXR24 ~+55%).
 - **Multi-threaded** (opt-in C11 threads, `make … THREADS=1` +
   `exr_set_num_threads(n)`): per-block parallel encode/decode scales **~5×
   (ZIP) to ~8.8× (ZIPS)** to 16 threads. At 16 threads TinyEXR **out-decodes
@@ -247,7 +254,8 @@ Contribution is welcome!
 - **Core** — 3-clause BSD, dependency-free. The HTJ2K/JPH and DEFLATE/PIZ/B44
   codec implementations are original in-tree code.
 - **zstd** (`deps/zstd/`, optional, on by default) — BSD-3-Clause, Facebook.
-- **libdeflate** (vendored, optional ZIP/ZIPS/PXR24 backend, off by default) —
+- **libdeflate** (vendored ZIP/ZIPS/PXR24 backend, default on hosted builds via
+  `DEFLATE=auto`; `DEFLATE=intree` and freestanding/WASM use the pure-C codec) —
   MIT.
 
 ---

--- a/include/exr.h
+++ b/include/exr.h
@@ -629,6 +629,25 @@ typedef enum exr_simd_caps {
 uint32_t exr_simd_capabilities(void);
 const char *exr_simd_info(void);
 
+/* zlib (DEFLATE) backend used by ZIP/ZIPS/PXR24. The in-tree pure-C codec is
+ * always available; the vendored libdeflate is compiled in for hosted builds
+ * (DEFLATE=auto|libdeflate) and is faster on natural-image data. Freestanding
+ * and WASM builds only ever have the in-tree codec. */
+typedef enum exr_zlib_backend {
+    EXR_ZLIB_AUTO = 0,    /* the build-time default backend */
+    EXR_ZLIB_INTREE,      /* force the in-tree pure-C codec */
+    EXR_ZLIB_LIBDEFLATE   /* force libdeflate (else EXR_ERROR_UNSUPPORTED) */
+} exr_zlib_backend;
+
+/* Select the zlib backend for subsequent (de)compression. Not thread-safe with
+ * concurrent decoding: call before kicking off a decode, not during one.
+ * Returns EXR_ERROR_UNSUPPORTED if libdeflate is requested but not compiled in
+ * (the backend is left unchanged). */
+exr_result exr_zlib_set_backend(exr_zlib_backend backend);
+
+/* Name of the active zlib backend ("in-tree" or "libdeflate"). */
+const char *exr_zlib_backend_name(void);
+
 /* Pixel-format conversion (runtime SIMD-dispatched). */
 void exr_half_to_float(const uint16_t *src, float *dst, size_t count);
 void exr_float_to_half(const float *src, uint16_t *dst, size_t count);

--- a/src/exr_codec.c
+++ b/src/exr_codec.c
@@ -7,6 +7,57 @@
 
 #include "exr_internal.h"
 
+/* ---- runtime zlib backend selection (ZIP/ZIPS/PXR24) ---------------------
+ * Statically initialised to the build default: libdeflate when it is compiled
+ * in and chosen as the default (DEFLATE=auto|libdeflate), otherwise the in-tree
+ * pure-C codec. exr_zlib_set_backend() overrides at runtime for tests/bench. */
+#if defined(EXR_USE_LIBDEFLATE) && EXR_ZLIB_DEFAULT_LIBDEFLATE
+exr_zlib_inflate_fn exr_zlib_inflate = exr_ld_inflate_zlib;
+exr_zlib_deflate_fn exr_zlib_deflate = exr_ld_deflate_zlib;
+#else
+exr_zlib_inflate_fn exr_zlib_inflate = exr_inflate_zlib;
+exr_zlib_deflate_fn exr_zlib_deflate = exr_deflate_zlib;
+#endif
+
+exr_result exr_zlib_set_backend(exr_zlib_backend backend) {
+#if defined(EXR_USE_LIBDEFLATE)
+    switch (backend) {
+    case EXR_ZLIB_INTREE:
+        exr_zlib_inflate = exr_inflate_zlib;
+        exr_zlib_deflate = exr_deflate_zlib;
+        return EXR_SUCCESS;
+    case EXR_ZLIB_LIBDEFLATE:
+        exr_zlib_inflate = exr_ld_inflate_zlib;
+        exr_zlib_deflate = exr_ld_deflate_zlib;
+        return EXR_SUCCESS;
+    case EXR_ZLIB_AUTO:
+    default:
+#if EXR_ZLIB_DEFAULT_LIBDEFLATE
+        exr_zlib_inflate = exr_ld_inflate_zlib;
+        exr_zlib_deflate = exr_ld_deflate_zlib;
+#else
+        exr_zlib_inflate = exr_inflate_zlib;
+        exr_zlib_deflate = exr_deflate_zlib;
+#endif
+        return EXR_SUCCESS;
+    }
+#else
+    /* Only the in-tree codec is linked; libdeflate cannot be selected. */
+    if (backend == EXR_ZLIB_LIBDEFLATE) return EXR_ERROR_UNSUPPORTED;
+    exr_zlib_inflate = exr_inflate_zlib;
+    exr_zlib_deflate = exr_deflate_zlib;
+    return EXR_SUCCESS;
+#endif
+}
+
+const char *exr_zlib_backend_name(void) {
+#if defined(EXR_USE_LIBDEFLATE)
+    return exr_zlib_inflate == exr_ld_inflate_zlib ? "libdeflate" : "in-tree";
+#else
+    return "in-tree";
+#endif
+}
+
 /*
  * Decompress one chunk's compressed payload into the canonical uncompressed
  * block layout (per scanline, then per channel: sample data).

--- a/src/exr_codec.c
+++ b/src/exr_codec.c
@@ -12,11 +12,11 @@
  * in and chosen as the default (DEFLATE=auto|libdeflate), otherwise the in-tree
  * pure-C codec. exr_zlib_set_backend() overrides at runtime for tests/bench. */
 #if defined(EXR_USE_LIBDEFLATE) && EXR_ZLIB_DEFAULT_LIBDEFLATE
-exr_zlib_inflate_fn exr_zlib_inflate = exr_ld_inflate_zlib;
-exr_zlib_deflate_fn exr_zlib_deflate = exr_ld_deflate_zlib;
+_Atomic exr_zlib_inflate_fn exr_zlib_inflate = exr_ld_inflate_zlib;
+_Atomic exr_zlib_deflate_fn exr_zlib_deflate = exr_ld_deflate_zlib;
 #else
-exr_zlib_inflate_fn exr_zlib_inflate = exr_inflate_zlib;
-exr_zlib_deflate_fn exr_zlib_deflate = exr_deflate_zlib;
+_Atomic exr_zlib_inflate_fn exr_zlib_inflate = exr_inflate_zlib;
+_Atomic exr_zlib_deflate_fn exr_zlib_deflate = exr_deflate_zlib;
 #endif
 
 exr_result exr_zlib_set_backend(exr_zlib_backend backend) {

--- a/src/exr_internal.h
+++ b/src/exr_internal.h
@@ -1004,21 +1004,38 @@ exr_result exr_deflate_zlib(const exr_allocator *a, const uint8_t *src,
 /* Adler-32 (zlib trailer). */
 uint32_t exr_adler32(const uint8_t *data, size_t n, uint32_t adler);
 
-/* Optional libdeflate backend for ZIP/ZIPS/PXR24 (gated by EXR_USE_LIBDEFLATE,
- * default off). The in-tree encoder/inflate above stay the default and remain
- * the only path for freestanding builds. ZIP/PXR24 call these via the
- * EXR_DEFLATE_ZLIB / EXR_INFLATE_ZLIB macros so the choice is a build flag. */
+/* libdeflate backend for ZIP/ZIPS/PXR24 (compiled in for DEFLATE=auto|libdeflate
+ * via EXR_USE_LIBDEFLATE). The in-tree encoder/inflate above remain the only
+ * path for freestanding and WASM builds. ZIP/PXR24 reach whichever backend is
+ * active through the exr_zlib_inflate / exr_zlib_deflate pointers below. */
 #ifdef EXR_USE_LIBDEFLATE
 exr_result exr_ld_deflate_zlib(const exr_allocator *a, const uint8_t *src,
                                size_t n, uint8_t **out_data, size_t *out_size);
 exr_result exr_ld_inflate_zlib(const uint8_t *src, size_t src_size, uint8_t *dst,
                                size_t dst_cap, size_t *out_size);
-#define EXR_DEFLATE_ZLIB exr_ld_deflate_zlib
-#define EXR_INFLATE_ZLIB exr_ld_inflate_zlib
-#else
-#define EXR_DEFLATE_ZLIB exr_deflate_zlib
-#define EXR_INFLATE_ZLIB exr_inflate_zlib
 #endif
+
+/* Build-time default for the runtime backend when both are compiled in. The
+ * Makefile sets this to 1 for DEFLATE=auto|libdeflate. Freestanding and WASM
+ * builds never define EXR_USE_LIBDEFLATE, so only the in-tree path is linked
+ * and the pointers below resolve to it regardless of this value. */
+#ifndef EXR_ZLIB_DEFAULT_LIBDEFLATE
+#define EXR_ZLIB_DEFAULT_LIBDEFLATE 0
+#endif
+
+/* Runtime-selectable zlib backend. ZIP/ZIPS/PXR24 call through these pointers
+ * (defined in exr_codec.c, statically initialised to the build default). When
+ * libdeflate is not compiled in they can only ever point at the in-tree codec.
+ * Override with exr_zlib_set_backend() (public, exr.h) before decoding; the
+ * pointers are read-only during decode, so do not flip them mid-run. */
+typedef exr_result (*exr_zlib_inflate_fn)(const uint8_t *src, size_t src_size,
+                                          uint8_t *dst, size_t dst_cap,
+                                          size_t *out_size);
+typedef exr_result (*exr_zlib_deflate_fn)(const exr_allocator *a,
+                                          const uint8_t *src, size_t n,
+                                          uint8_t **out_data, size_t *out_size);
+extern exr_zlib_inflate_fn exr_zlib_inflate;
+extern exr_zlib_deflate_fn exr_zlib_deflate;
 
 /* fpnge-derived literal DEFLATE encoder with a PSHUFB Huffman-table lookup.
  * The PSHUFB-friendly table: symbols 0-15 and 240-255 are looked up by low

--- a/src/exr_internal.h
+++ b/src/exr_internal.h
@@ -1034,8 +1034,13 @@ typedef exr_result (*exr_zlib_inflate_fn)(const uint8_t *src, size_t src_size,
 typedef exr_result (*exr_zlib_deflate_fn)(const exr_allocator *a,
                                           const uint8_t *src, size_t n,
                                           uint8_t **out_data, size_t *out_size);
-extern exr_zlib_inflate_fn exr_zlib_inflate;
-extern exr_zlib_deflate_fn exr_zlib_deflate;
+/* _Atomic so a write in exr_zlib_set_backend() races defined-behaviour-ly with
+ * reads in the codec functions: a concurrent reader sees old-or-new, never a
+ * torn value. (The documented contract is still "set before decoding"; this is
+ * belt-and-suspenders.) Pointer-sized atomics are lock-free and lower to plain
+ * loads/stores, so this adds no libcall and stays freestanding-clean. */
+extern _Atomic exr_zlib_inflate_fn exr_zlib_inflate;
+extern _Atomic exr_zlib_deflate_fn exr_zlib_deflate;
 
 /* fpnge-derived literal DEFLATE encoder with a PSHUFB Huffman-table lookup.
  * The PSHUFB-friendly table: symbols 0-15 and 240-255 are looked up by low

--- a/src/exr_libdeflate.c
+++ b/src/exr_libdeflate.c
@@ -71,6 +71,14 @@ exr_result exr_ld_inflate_zlib(const uint8_t *src, size_t src_size, uint8_t *dst
     size_t actual = 0;
 
     if (out_size) *out_size = 0;
+    /* Allocate per block rather than caching a per-thread decompressor. The
+     * decompressor is a fixed-size struct whose decode tables are (re)built
+     * inside libdeflate_zlib_decompress, so the alloc is a single malloc that
+     * is negligible next to the decode: measured identical throughput vs a
+     * reused _Thread_local decompressor, both single-threaded and 8-way (the
+     * 128-512 KB per-block decode dwarfs the alloc, and glibc's per-thread
+     * arenas absorb it). Per-call keeps this trivially thread-safe and leak
+     * free under exr_parallel_for's spawn/join workers. */
     d = libdeflate_alloc_decompressor();
     if (!d) return EXR_ERROR_OUT_OF_MEMORY;
     r = libdeflate_zlib_decompress(d, src, src_size, dst, dst_cap, &actual);

--- a/src/exr_piz.c
+++ b/src/exr_piz.c
@@ -166,18 +166,21 @@ static uint64_t hgetbits(int nb, uint64_t *c, int *lc, const uint8_t **in,
     return (*c >> *lc) & ((UINT64_C(1) << nb) - 1u);
 }
 
-static void canonical_code_table(int64_t *hcode) {
+/* Only hcode[im..iM] can be non-zero (symbols outside that span have length 0);
+ * the length-0 count n[0] is never used, so restricting both full-table scans to
+ * [im..iM] is equivalent and avoids walking all 65537 slots per block. */
+static void canonical_code_table(int64_t *hcode, int im, int iM) {
     int64_t n[59];
     int i;
     int64_t c = 0;
     for (i = 0; i <= 58; ++i) n[i] = 0;
-    for (i = 0; i < PIZ_HUF_ENCSIZE; ++i) n[hcode[i]]++;
+    for (i = im; i <= iM; ++i) n[hcode[i]]++;
     for (i = 58; i > 0; --i) {
         int64_t nc = ((c + n[i]) >> 1);
         n[i] = c;
         c = nc;
     }
-    for (i = 0; i < PIZ_HUF_ENCSIZE; ++i) {
+    for (i = im; i <= iM; ++i) {
         int l = (int)hcode[i];
         if (l > 0) hcode[i] = l | (n[l]++ << 6);
     }
@@ -189,6 +192,7 @@ static int unpack_enc_table(const uint8_t **pcode, int ni, int im, int iM,
     const uint8_t *end = *pcode + ni;
     uint64_t c = 0;
     int lc = 0;
+    int im0 = im;
     memset(hcode, 0, sizeof(int64_t) * PIZ_HUF_ENCSIZE);
     for (; im <= iM; im++) {
         int64_t l;
@@ -210,7 +214,7 @@ static int unpack_enc_table(const uint8_t **pcode, int ni, int im, int iM,
         }
     }
     *pcode = p;
-    canonical_code_table(hcode);
+    canonical_code_table(hcode, im0, iM);
     return 1;
 }
 
@@ -354,9 +358,17 @@ static int huf_uncompress(const exr_allocator *a, const uint8_t *in,
             const HufDec *pl = &hdecod[(c >> (lc - HUF_DECBITS)) & HUF_DECMASK];
             if (pl->len) {
                 lc -= (int)pl->len;
-                if (!get_code((int)pl->lit, rlc, &c, &lc, &ptr, ie, &outp, outb,
-                              oe))
+                /* Hot path: most symbols are plain literals (not the run-length
+                 * code), which get_code() would emit as a single store. Inline
+                 * that case to avoid a 9-argument call per decoded symbol; only
+                 * the actual RLE marker falls through to get_code(). */
+                if ((int)pl->lit != rlc) {
+                    if (outp >= oe) goto cleanup;
+                    *outp++ = (uint16_t)pl->lit;
+                } else if (!get_code((int)pl->lit, rlc, &c, &lc, &ptr, ie, &outp,
+                                     outb, oe)) {
                     goto cleanup;
+                }
             } else {
                 uint32_t j;
                 if (!pl->p) goto cleanup;
@@ -714,7 +726,7 @@ static int huf_build_enc_table(const exr_allocator *a, int64_t *frq, int *pim,
         }
     }
 
-    canonical_code_table(scode);
+    canonical_code_table(scode, im, iM);
     memcpy(frq, scode, sizeof(int64_t) * PIZ_HUF_ENCSIZE);
     *pim = im;
     *piM = iM;

--- a/src/exr_pxr24.c
+++ b/src/exr_pxr24.c
@@ -55,7 +55,7 @@ exr_result exr_pxr24_decompress(const exr_codec_ctx *ctx, const uint8_t *src,
         memcpy(buf, src, inter);
     } else {
         size_t got = 0;
-        rc = EXR_INFLATE_ZLIB(src, src_size, buf, inter, &got);
+        rc = exr_zlib_inflate(src, src_size, buf, inter, &got);
         if (EXR_OK(rc) && got != inter) rc = EXR_ERROR_CORRUPT;
         if (!EXR_OK(rc)) {
             exr_free(a, buf);
@@ -240,7 +240,7 @@ exr_result exr_pxr24_compress(const exr_codec_ctx *ctx, const uint8_t *block,
         }
     }
 
-    rc = EXR_DEFLATE_ZLIB(a, buf, inter, &comp, &clen);
+    rc = exr_zlib_deflate(a, buf, inter, &comp, &clen);
     exr_free(a, buf);
     if (!EXR_OK(rc) || clen >= n) { /* store the canonical block raw */
         exr_free(a, comp);

--- a/src/exr_zip.c
+++ b/src/exr_zip.c
@@ -11,7 +11,7 @@
 exr_result exr_zip_inflate_only(const uint8_t *src, size_t src_size,
                                 uint8_t *dst, size_t dst_size) {
     size_t out_size = 0;
-    exr_result rc = EXR_INFLATE_ZLIB(src, src_size, dst, dst_size, &out_size);
+    exr_result rc = exr_zlib_inflate(src, src_size, dst, dst_size, &out_size);
     if (EXR_OK(rc) && out_size != dst_size) rc = EXR_ERROR_CORRUPT;
     return rc;
 }
@@ -50,7 +50,7 @@ exr_result exr_zip_compress(const exr_allocator *a, const uint8_t *src, size_t n
     exr_interleave_encode(src, tmp, n);
     exr_predictor_encode(tmp, n);
 
-    rc = EXR_DEFLATE_ZLIB(a, tmp, n, &comp, &clen);
+    rc = exr_zlib_deflate(a, tmp, n, &comp, &clen);
     exr_free(a, tmp);
 
     if (!EXR_OK(rc) || clen >= n) { /* store original canonical block raw */

--- a/test/unit/test_exr_v3.c
+++ b/test/unit/test_exr_v3.c
@@ -3393,31 +3393,34 @@ static void zlib_backend_parity_tests(void) {
         }
     }
 
-    /* Cross-backend: a stream written by one backend decodes under the other. */
+    /* Cross-backend: a stream written by one backend decodes under the other,
+     * reproducing every channel. Free the decoded image unconditionally so a
+     * detected mismatch does not leak under LSan. */
     if (have_ld) {
         exr_image dec;
+        int match;
         exr_zlib_set_backend(EXR_ZLIB_INTREE);
         rc = exr_save_to_memory(&bufA, &szA, NULL, &img, EXR_COMPRESSION_ZIP);
         exr_zlib_set_backend(EXR_ZLIB_LIBDEFLATE);
-        if (EXR_OK(rc)) {
-            memset(&dec, 0, sizeof(dec));
-            if (!EXR_OK(exr_load_from_memory(bufA, szA, NULL, &dec)) ||
-                memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) != 0)
-                ok = 0;
-            else
-                exr_image_free(&dec);
-        } else ok = 0;
+        memset(&dec, 0, sizeof(dec));
+        match = EXR_OK(rc) && EXR_OK(exr_load_from_memory(bufA, szA, NULL, &dec));
+        if (match) {
+            match = memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) == 0 &&
+                    memcmp(dec.parts[0].images[1], px[1], sizeof(px[1])) == 0;
+            exr_image_free(&dec);
+        }
+        if (!match) ok = 0;
 
         rc = exr_save_to_memory(&bufB, &szB, NULL, &img, EXR_COMPRESSION_ZIP);
         exr_zlib_set_backend(EXR_ZLIB_INTREE);
-        if (EXR_OK(rc)) {
-            memset(&dec, 0, sizeof(dec));
-            if (!EXR_OK(exr_load_from_memory(bufB, szB, NULL, &dec)) ||
-                memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) != 0)
-                ok = 0;
-            else
-                exr_image_free(&dec);
-        } else ok = 0;
+        memset(&dec, 0, sizeof(dec));
+        match = EXR_OK(rc) && EXR_OK(exr_load_from_memory(bufB, szB, NULL, &dec));
+        if (match) {
+            match = memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) == 0 &&
+                    memcmp(dec.parts[0].images[1], px[1], sizeof(px[1])) == 0;
+            exr_image_free(&dec);
+        }
+        if (!match) ok = 0;
         free(bufA);
         free(bufB);
     }

--- a/test/unit/test_exr_v3.c
+++ b/test/unit/test_exr_v3.c
@@ -3323,6 +3323,111 @@ static void simd_zip_kernel_parity_tests(void) {
     free(seed); free(ref); free(got); free(dref); free(dgot);
 }
 
+/* The in-tree and libdeflate zlib backends must be losslessly interchangeable:
+ * every available backend reproduces the original ZIP-encoded pixels exactly,
+ * and a stream written by one backend decodes correctly under the other. When
+ * libdeflate is not compiled in, exr_zlib_set_backend(LIBDEFLATE) reports
+ * UNSUPPORTED and only the in-tree round-trip runs. */
+static void zlib_backend_parity_tests(void) {
+    enum { W = 96, H = 64, NC = 2, NPX = W * H };
+    static uint16_t px[NC][NPX];
+    exr_image img;
+    exr_part part;
+    exr_channel ch[NC];
+    void *images[NC];
+    uint32_t rng = 0x2468ACEu;
+    int c, i, ok = 1, ran = 0;
+    void *bufA = NULL, *bufB = NULL;
+    size_t szA = 0, szB = 0;
+    exr_result rc;
+    int have_ld;
+
+    for (c = 0; c < NC; c++)
+        for (i = 0; i < NPX; i++) {
+            rng = rng * 1664525u + 1013904223u;
+            px[c][i] = (uint16_t)((rng >> 13) & 0x3fffu); /* mildly compressible */
+        }
+    memset(&img, 0, sizeof(img));
+    memset(&part, 0, sizeof(part));
+    memset(ch, 0, sizeof(ch));
+    img.num_parts = 1;
+    img.parts = &part;
+    part.header.num_channels = NC;
+    part.header.channels = ch;
+    ch[0] = (exr_channel){"A", EXR_PIXEL_HALF, 1, 1, 0};
+    ch[1] = (exr_channel){"B", EXR_PIXEL_HALF, 1, 1, 0};
+    part.header.data_window.max_x = W - 1;
+    part.header.data_window.max_y = H - 1;
+    part.header.display_window = part.header.data_window;
+    part.width = W;
+    part.height = H;
+    part.images = images;
+    images[0] = px[0];
+    images[1] = px[1];
+
+    have_ld = (exr_zlib_set_backend(EXR_ZLIB_LIBDEFLATE) == EXR_SUCCESS);
+    exr_zlib_set_backend(EXR_ZLIB_AUTO);
+
+    /* Each available backend must encode+decode ZIP losslessly. */
+    {
+        const exr_zlib_backend tiers[2] = {EXR_ZLIB_INTREE, EXR_ZLIB_LIBDEFLATE};
+        int t;
+        for (t = 0; t < 2; t++) {
+            void *buf = NULL;
+            size_t sz = 0;
+            exr_image dec;
+            if (exr_zlib_set_backend(tiers[t]) != EXR_SUCCESS) continue;
+            if (!EXR_OK(exr_save_to_memory(&buf, &sz, NULL, &img,
+                                           EXR_COMPRESSION_ZIP))) { ok = 0; continue; }
+            memset(&dec, 0, sizeof(dec));
+            if (!EXR_OK(exr_load_from_memory(buf, sz, NULL, &dec))) {
+                ok = 0; free(buf); continue;
+            }
+            if (dec.num_parts != 1 ||
+                memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) != 0 ||
+                memcmp(dec.parts[0].images[1], px[1], sizeof(px[1])) != 0)
+                ok = 0;
+            ran++;
+            exr_image_free(&dec);
+            free(buf);
+        }
+    }
+
+    /* Cross-backend: a stream written by one backend decodes under the other. */
+    if (have_ld) {
+        exr_image dec;
+        exr_zlib_set_backend(EXR_ZLIB_INTREE);
+        rc = exr_save_to_memory(&bufA, &szA, NULL, &img, EXR_COMPRESSION_ZIP);
+        exr_zlib_set_backend(EXR_ZLIB_LIBDEFLATE);
+        if (EXR_OK(rc)) {
+            memset(&dec, 0, sizeof(dec));
+            if (!EXR_OK(exr_load_from_memory(bufA, szA, NULL, &dec)) ||
+                memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) != 0)
+                ok = 0;
+            else
+                exr_image_free(&dec);
+        } else ok = 0;
+
+        rc = exr_save_to_memory(&bufB, &szB, NULL, &img, EXR_COMPRESSION_ZIP);
+        exr_zlib_set_backend(EXR_ZLIB_INTREE);
+        if (EXR_OK(rc)) {
+            memset(&dec, 0, sizeof(dec));
+            if (!EXR_OK(exr_load_from_memory(bufB, szB, NULL, &dec)) ||
+                memcmp(dec.parts[0].images[0], px[0], sizeof(px[0])) != 0)
+                ok = 0;
+            else
+                exr_image_free(&dec);
+        } else ok = 0;
+        free(bufA);
+        free(bufB);
+    }
+
+    exr_zlib_set_backend(EXR_ZLIB_AUTO);
+    CHECK(ok && ran >= 1, "zlib backends round-trip ZIP losslessly + interop");
+    printf("  ok: zlib backend = %s (libdeflate %s)\n", exr_zlib_backend_name(),
+           have_ld ? "compiled in" : "not compiled");
+}
+
 static void util_resize_tests(void) {
     const exr_allocator *a = NULL;
     int w = 8, h = 6, i;
@@ -3548,6 +3653,7 @@ static void util_tests(void) {
     printf("== util: SIMD parity ==\n");
     util_simd_parity_tests();
     simd_zip_kernel_parity_tests();
+    zlib_backend_parity_tests();
     printf("== util: resize ==\n");
     util_resize_tests();
     printf("== util: tonemap ==\n");


### PR DESCRIPTION
Decode-path performance work, validated on the `openexr-images` and ALab `texture_pack` corpora.

## Commits

1. **`exr_piz`: faster PIZ decode (+14%)** — inline the literal store in the Huffman hot loop (get_code calls 640M→22M) and restrict `canonical_code_table`'s 65537-slot scans to `[im..iM]`. PIZ decode ~80→92 Mpix/s; all 36 openexr-images PIZ files byte-identical before/after.
2. **Runtime-selectable zlib backend; libdeflate default on hosted** — replace the compile-time macro swap with `exr_zlib_inflate`/`exr_zlib_deflate` pointers + public `exr_zlib_set_backend()`/`exr_zlib_backend_name()`. Makefile `DEFLATE=auto|libdeflate|intree` (default `auto`). Freestanding + WASM stay in-tree (proven by the freestanding gate). Adds `fuzz-libdeflate` + a cross-backend ZIP identity unit test.
3. **Document the per-block decompressor allocation** — measured reuse is a no-op (identical throughput single- and 8-threaded), recorded so it isn't re-attempted.
4. **README** for `DEFLATE=auto`.

## Why

The in-tree pure-C inflate is competitive on smooth data but ~60–80% slower than libdeflate on natural-image ZIP/ZIPS/PXR24 (symbol-decode-bound; micro-opts don't close it). libdeflate is already vendored and byte-identical, so make it the hosted default while keeping the in-tree codec for freestanding/WASM/`intree`.

Default-build decode on openexr-images: **ZIP 226→391, ZIPS 171→278, PXR24 309→479 Mpix/s.**

## Verification

- 268/268 unit tests pass under both `DEFLATE=auto` and `DEFLATE=intree` (ASan/UBSan).
- freestanding gate + c11 gate green.
- `make fuzz-corpus` (ASan/UBSan/**LSan**) clean with libdeflate default; `fuzz-libdeflate` (60s libFuzzer) clean.
- PIZ + ZIP decode byte-identical before/after and across backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)