### PR TITLE
ci: re-enable aarch64 freestanding gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,14 +184,17 @@ jobs:
         run: make fuzz-corpus
 
   freestanding:
-    name: linux-x64-freestanding-gate
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 10
-    # NOTE: aarch64 coverage is wanted (validates the static-DCtx workspace
-    # alignment), but the v3 freestanding core does not yet compile on aarch64 -
-    # src/exr_jph.c references AVX2 symbols (JphFrwdAvx2, jph_frwd_init_ff_avx2,
-    # ...) that are not guarded by EXR_X86 in that path. That is orthogonal to
-    # zstd; add an arm64 freestanding job once exr_jph.c builds there.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64-freestanding-gate
+            runs_on: ubuntu-latest
+          - name: linux-arm64-freestanding-gate
+            runs_on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Now that `src/exr_jph.c` compiles on aarch64 (#248), restore the `linux-arm64-freestanding-gate` entry to the freestanding job matrix that #247 had reverted to x86-only.

This gives real aarch64 coverage to:
- the v3 **freestanding core** (no-libc build), and
- the **`EXR_FREESTANDING_ZSTD`** static-DCtx decode path — in particular the workspace **alignment** that the review of #247 flagged.

Both `make freestanding-gate` and `make freestanding-zstd-gate` were verified locally on aarch64 (`aarch64-linux-gnu-gcc-13` compiles the whole core; arm-smoke round-trips under qemu), so the new job should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)