### PR TITLE
doc: in-tree-vs-libdeflate corpus decode chart + reproducible generator

### DIFF
--- a/doc/gen_perf_charts.py
+++ b/doc/gen_perf_charts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Generate the hand-styled perf SVGs in doc/ from inline data (stdlib only).
+
+The charts in doc/ were originally hand-authored SVG; this reproduces that exact
+minimal style (620x400, blue=in-tree / green=libdeflate / amber=OpenEXR, value
+labels above bars, light gridlines) so the data-bearing ones can be regenerated.
+
+    python3 doc/gen_perf_charts.py        # writes the *.svg next to this script
+
+Colors:  in-tree #2563eb, libdeflate #16a34a, OpenEXR #f59e0b
+"""
+
+import os
+
+W, H = 620, 400
+X0, X1 = 60.0, 602.0          # plot x-range
+Y0, YTOP = 328.0, 64.0        # y of value 0 and of y-max
+CY = {"intree": "#2563eb", "libdeflate": "#16a34a", "openexr": "#f59e0b"}
+
+
+def _fmt(v):
+    return ("%.1f" % v).rstrip("0").rstrip(".") if v % 1 else "%d" % v
+
+
+def chart(path, title, subtitle, cats, series, ymax, ytick):
+    """series: list of (label, color, [value per cat]). cats: list of names."""
+    span = Y0 - YTOP
+    def y(v):
+        return Y0 - (v / ymax) * span
+    out = []
+    out.append('<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" '
+               'viewBox="0 0 %d %d" font-family="-apple-system,Segoe UI,Roboto,'
+               'sans-serif">' % (W, H, W, H))
+    out.append('<rect width="%d" height="%d" fill="#fff"/>' % (W, H))
+    out.append('<text x="60" y="26" font-size="17" font-weight="700" '
+               'fill="#111">%s</text>' % title)
+    out.append('<text x="60" y="44" font-size="12" fill="#666">%s</text>' % subtitle)
+    # gridlines + y labels
+    t = 0
+    while t <= ymax + 1e-9:
+        gy = y(t)
+        out.append('<line x1="60" y1="%.1f" x2="602" y2="%.1f" stroke="#eee"/>'
+                   % (gy, gy))
+        out.append('<text x="52" y="%.1f" font-size="11" fill="#888" '
+                   'text-anchor="end">%s</text>' % (gy + 4, _fmt(t)))
+        t += ytick
+    out.append('<text x="16" y="196" font-size="12" fill="#666" '
+               'transform="rotate(-90 16 196)" text-anchor="middle">'
+               'megapixels / s</text>')
+    # bars
+    ncat = len(cats)
+    nser = len(series)
+    group_w = (X1 - X0) / ncat
+    bw = min(42.6, group_w * 0.78 / nser)
+    for ci, cat in enumerate(cats):
+        gx = X0 + ci * group_w
+        inner = nser * bw
+        start = gx + (group_w - inner) / 2.0
+        for si, (label, color, vals) in enumerate(series):
+            v = vals[ci]
+            bx = start + si * bw
+            by = y(v)
+            out.append('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" '
+                       'fill="%s" rx="2"/>' % (bx, by, bw, Y0 - by, color))
+            out.append('<text x="%.1f" y="%.1f" font-size="9" fill="#444" '
+                       'text-anchor="middle">%s</text>'
+                       % (bx + bw / 2.0, by - 4, _fmt(v)))
+        out.append('<text x="%.1f" y="346" font-size="12" fill="#333" '
+                   'text-anchor="middle">%s</text>'
+                   % (gx + group_w / 2.0, cat))
+    out.append('<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#bbb"/>')
+    # legend
+    lx = 60
+    for label, color, _ in series:
+        out.append('<rect x="%d" y="370" width="12" height="12" fill="%s" '
+                   'rx="2"/>' % (lx, color))
+        out.append('<text x="%d" y="380" font-size="12" fill="#333">%s</text>'
+                   % (lx + 17, label))
+        lx += 24 + int(7.0 * len(label))
+    out.append('</svg>')
+    with open(path, "w") as f:
+        f.write("\n".join(out) + "\n")
+    print("wrote", path)
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    # Decode throughput, in-tree vs libdeflate, openexr-images natural corpus.
+    # Measured with test/v3/bench_decode (single thread, decode-only, Mpix/s).
+    chart(
+        os.path.join(here, "perf-libdeflate-corpus-decode.svg"),
+        "Decode throughput - in-tree vs libdeflate (natural-image corpus)",
+        "openexr-images; libdeflate is the DEFLATE=auto hosted default.",
+        ["zip", "zips", "pxr24"],
+        [("tinyexr (in-tree)", CY["intree"], [226, 171, 309]),
+         ("tinyexr (libdeflate)", CY["libdeflate"], [391, 278, 479])],
+        ymax=500, ytick=100,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/perf-libdeflate-corpus-decode.svg
+++ b/doc/perf-libdeflate-corpus-decode.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="400" viewBox="0 0 620 400" font-family="-apple-system,Segoe UI,Roboto,sans-serif">
+<rect width="620" height="400" fill="#fff"/>
+<text x="60" y="26" font-size="17" font-weight="700" fill="#111">Decode throughput - in-tree vs libdeflate (natural-image corpus)</text>
+<text x="60" y="44" font-size="12" fill="#666">openexr-images; libdeflate is the DEFLATE=auto hosted default.</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#eee"/>
+<text x="52" y="332.0" font-size="11" fill="#888" text-anchor="end">0</text>
+<line x1="60" y1="275.2" x2="602" y2="275.2" stroke="#eee"/>
+<text x="52" y="279.2" font-size="11" fill="#888" text-anchor="end">100</text>
+<line x1="60" y1="222.4" x2="602" y2="222.4" stroke="#eee"/>
+<text x="52" y="226.4" font-size="11" fill="#888" text-anchor="end">200</text>
+<line x1="60" y1="169.6" x2="602" y2="169.6" stroke="#eee"/>
+<text x="52" y="173.6" font-size="11" fill="#888" text-anchor="end">300</text>
+<line x1="60" y1="116.8" x2="602" y2="116.8" stroke="#eee"/>
+<text x="52" y="120.8" font-size="11" fill="#888" text-anchor="end">400</text>
+<line x1="60" y1="64.0" x2="602" y2="64.0" stroke="#eee"/>
+<text x="52" y="68.0" font-size="11" fill="#888" text-anchor="end">500</text>
+<text x="16" y="196" font-size="12" fill="#666" transform="rotate(-90 16 196)" text-anchor="middle">megapixels / s</text>
+<rect x="107.7" y="208.7" width="42.6" height="119.3" fill="#2563eb" rx="2"/>
+<text x="129.0" y="204.7" font-size="9" fill="#444" text-anchor="middle">226</text>
+<rect x="150.3" y="121.6" width="42.6" height="206.4" fill="#16a34a" rx="2"/>
+<text x="171.6" y="117.6" font-size="9" fill="#444" text-anchor="middle">391</text>
+<text x="150.3" y="346" font-size="12" fill="#333" text-anchor="middle">zip</text>
+<rect x="288.4" y="237.7" width="42.6" height="90.3" fill="#2563eb" rx="2"/>
+<text x="309.7" y="233.7" font-size="9" fill="#444" text-anchor="middle">171</text>
+<rect x="331.0" y="181.2" width="42.6" height="146.8" fill="#16a34a" rx="2"/>
+<text x="352.3" y="177.2" font-size="9" fill="#444" text-anchor="middle">278</text>
+<text x="331.0" y="346" font-size="12" fill="#333" text-anchor="middle">zips</text>
+<rect x="469.1" y="164.8" width="42.6" height="163.2" fill="#2563eb" rx="2"/>
+<text x="490.4" y="160.8" font-size="9" fill="#444" text-anchor="middle">309</text>
+<rect x="511.7" y="75.1" width="42.6" height="252.9" fill="#16a34a" rx="2"/>
+<text x="533.0" y="71.1" font-size="9" fill="#444" text-anchor="middle">479</text>
+<text x="511.7" y="346" font-size="12" fill="#333" text-anchor="middle">pxr24</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#bbb"/>
+<rect x="60" y="370" width="12" height="12" fill="#2563eb" rx="2"/>
+<text x="77" y="380" font-size="12" fill="#333">tinyexr (in-tree)</text>
+<rect x="203" y="370" width="12" height="12" fill="#16a34a" rx="2"/>
+<text x="220" y="380" font-size="12" fill="#333">tinyexr (libdeflate)</text>
+</svg>

--- a/doc/performance-vs-openexr.md
+++ b/doc/performance-vs-openexr.md
@@ -117,6 +117,10 @@ actually edges libdeflate by ~8%. libdeflate is the safer default for the
 diverse real-world case; the in-tree codec stays best for tiny/freestanding
 builds.
 
+![Decode: in-tree vs libdeflate on the natural-image corpus](perf-libdeflate-corpus-decode.svg)
+
+*(`doc/gen_perf_charts.py` regenerates the data-bearing SVGs.)*
+
 **PIZ decode** got a separate ~**+14%** (≈80→92 Mpix/s on the corpus) from
 inlining the Huffman literal store and restricting the canonical-code-table
 scan to the live symbol range. **ZSTD** decode (vendored upstream, already


### PR DESCRIPTION
Adds a perf chart for this cycle's headline data and a reproducible generator.

- **`doc/perf-libdeflate-corpus-decode.svg`** — grouped bars (in-tree vs libdeflate) for the natural-image corpus decode lift that motivates `DEFLATE=auto`: ZIP 226→391, ZIPS 171→278, PXR24 309→479 Mpix/s. Embedded in `doc/performance-vs-openexr.md` next to the "Why it's the default" numbers.
- **`doc/gen_perf_charts.py`** — the doc SVGs were hand-authored with no generator; this stdlib-only script reproduces the exact house style (620×400, blue=in-tree / green=libdeflate / amber=OpenEXR, value labels, gridlines) and emits the data-bearing SVG deterministically, so it can be regenerated from the numbers.

Docs/asset only. SVG validated as well-formed XML; output verified deterministic (re-run is byte-identical). No renderer was available in-env, so layout was verified by inspecting the generated coordinates against the existing charts' geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)