### PR TITLE
doc: PIZ before/after + ZSTD-vs-ZIP decode charts

### DIFF
--- a/doc/gen_perf_charts.py
+++ b/doc/gen_perf_charts.py
@@ -16,7 +16,8 @@ import os
 W, H = 620, 400
 X0, X1 = 60.0, 602.0          # plot x-range
 Y0, YTOP = 328.0, 64.0        # y of value 0 and of y-max
-CY = {"intree": "#2563eb", "libdeflate": "#16a34a", "openexr": "#f59e0b"}
+CY = {"intree": "#2563eb", "libdeflate": "#16a34a", "openexr": "#f59e0b",
+      "before": "#9ca3af", "zstd": "#7c3aed"}
 
 
 def _fmt(v):
@@ -97,6 +98,30 @@ def main():
         [("tinyexr (in-tree)", CY["intree"], [226, 171, 309]),
          ("tinyexr (libdeflate)", CY["libdeflate"], [391, 278, 479])],
         ymax=500, ytick=100,
+    )
+
+    # PIZ decode before/after the in-tree optimization (best-of-8 on the 36
+    # openexr-images PIZ files; inline Huffman literal + tighter canonical scan).
+    chart(
+        os.path.join(here, "perf-piz-decode.svg"),
+        "PIZ decode - in-tree optimization (+14%)",
+        "openexr-images; inline Huffman literal store + tighter canonical scan.",
+        ["piz decode"],
+        [("before", CY["before"], [80.2]),
+         ("after", CY["intree"], [91.6])],
+        ymax=100, ytick=20,
+    )
+
+    # ZSTD vs ZIP decode on identical images (6 openexr-images ScanLines files
+    # re-encoded to each; both decoded with the default hosted build).
+    chart(
+        os.path.join(here, "perf-zstd-decode.svg"),
+        "ZSTD vs ZIP decode - identical images",
+        "6 openexr-images ScanLines files re-encoded to each codec.",
+        ["decode"],
+        [("zstd (vendored)", CY["zstd"], [410]),
+         ("zip (libdeflate)", CY["libdeflate"], [272])],
+        ymax=450, ytick=90,
     )
 
 

--- a/doc/perf-piz-decode.svg
+++ b/doc/perf-piz-decode.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="400" viewBox="0 0 620 400" font-family="-apple-system,Segoe UI,Roboto,sans-serif">
+<rect width="620" height="400" fill="#fff"/>
+<text x="60" y="26" font-size="17" font-weight="700" fill="#111">PIZ decode - in-tree optimization (+14%)</text>
+<text x="60" y="44" font-size="12" fill="#666">openexr-images; inline Huffman literal store + tighter canonical scan.</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#eee"/>
+<text x="52" y="332.0" font-size="11" fill="#888" text-anchor="end">0</text>
+<line x1="60" y1="275.2" x2="602" y2="275.2" stroke="#eee"/>
+<text x="52" y="279.2" font-size="11" fill="#888" text-anchor="end">20</text>
+<line x1="60" y1="222.4" x2="602" y2="222.4" stroke="#eee"/>
+<text x="52" y="226.4" font-size="11" fill="#888" text-anchor="end">40</text>
+<line x1="60" y1="169.6" x2="602" y2="169.6" stroke="#eee"/>
+<text x="52" y="173.6" font-size="11" fill="#888" text-anchor="end">60</text>
+<line x1="60" y1="116.8" x2="602" y2="116.8" stroke="#eee"/>
+<text x="52" y="120.8" font-size="11" fill="#888" text-anchor="end">80</text>
+<line x1="60" y1="64.0" x2="602" y2="64.0" stroke="#eee"/>
+<text x="52" y="68.0" font-size="11" fill="#888" text-anchor="end">100</text>
+<text x="16" y="196" font-size="12" fill="#666" transform="rotate(-90 16 196)" text-anchor="middle">megapixels / s</text>
+<rect x="288.4" y="116.3" width="42.6" height="211.7" fill="#9ca3af" rx="2"/>
+<text x="309.7" y="112.3" font-size="9" fill="#444" text-anchor="middle">80.2</text>
+<rect x="331.0" y="86.2" width="42.6" height="241.8" fill="#2563eb" rx="2"/>
+<text x="352.3" y="82.2" font-size="9" fill="#444" text-anchor="middle">91.6</text>
+<text x="331.0" y="346" font-size="12" fill="#333" text-anchor="middle">piz decode</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#bbb"/>
+<rect x="60" y="370" width="12" height="12" fill="#9ca3af" rx="2"/>
+<text x="77" y="380" font-size="12" fill="#333">before</text>
+<rect x="126" y="370" width="12" height="12" fill="#2563eb" rx="2"/>
+<text x="143" y="380" font-size="12" fill="#333">after</text>
+</svg>

--- a/doc/perf-zstd-decode.svg
+++ b/doc/perf-zstd-decode.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="400" viewBox="0 0 620 400" font-family="-apple-system,Segoe UI,Roboto,sans-serif">
+<rect width="620" height="400" fill="#fff"/>
+<text x="60" y="26" font-size="17" font-weight="700" fill="#111">ZSTD vs ZIP decode - identical images</text>
+<text x="60" y="44" font-size="12" fill="#666">6 openexr-images ScanLines files re-encoded to each codec.</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#eee"/>
+<text x="52" y="332.0" font-size="11" fill="#888" text-anchor="end">0</text>
+<line x1="60" y1="275.2" x2="602" y2="275.2" stroke="#eee"/>
+<text x="52" y="279.2" font-size="11" fill="#888" text-anchor="end">90</text>
+<line x1="60" y1="222.4" x2="602" y2="222.4" stroke="#eee"/>
+<text x="52" y="226.4" font-size="11" fill="#888" text-anchor="end">180</text>
+<line x1="60" y1="169.6" x2="602" y2="169.6" stroke="#eee"/>
+<text x="52" y="173.6" font-size="11" fill="#888" text-anchor="end">270</text>
+<line x1="60" y1="116.8" x2="602" y2="116.8" stroke="#eee"/>
+<text x="52" y="120.8" font-size="11" fill="#888" text-anchor="end">360</text>
+<line x1="60" y1="64.0" x2="602" y2="64.0" stroke="#eee"/>
+<text x="52" y="68.0" font-size="11" fill="#888" text-anchor="end">450</text>
+<text x="16" y="196" font-size="12" fill="#666" transform="rotate(-90 16 196)" text-anchor="middle">megapixels / s</text>
+<rect x="288.4" y="87.5" width="42.6" height="240.5" fill="#7c3aed" rx="2"/>
+<text x="309.7" y="83.5" font-size="9" fill="#444" text-anchor="middle">410</text>
+<rect x="331.0" y="168.4" width="42.6" height="159.6" fill="#16a34a" rx="2"/>
+<text x="352.3" y="164.4" font-size="9" fill="#444" text-anchor="middle">272</text>
+<text x="331.0" y="346" font-size="12" fill="#333" text-anchor="middle">decode</text>
+<line x1="60" y1="328.0" x2="602" y2="328.0" stroke="#bbb"/>
+<rect x="60" y="370" width="12" height="12" fill="#7c3aed" rx="2"/>
+<text x="77" y="380" font-size="12" fill="#333">zstd (vendored)</text>
+<rect x="189" y="370" width="12" height="12" fill="#16a34a" rx="2"/>
+<text x="206" y="380" font-size="12" fill="#333">zip (libdeflate)</text>
+</svg>

--- a/doc/performance-vs-openexr.md
+++ b/doc/performance-vs-openexr.md
@@ -123,9 +123,15 @@ builds.
 
 **PIZ decode** got a separate ~**+14%** (≈80→92 Mpix/s on the corpus) from
 inlining the Huffman literal store and restricting the canonical-code-table
-scan to the live symbol range. **ZSTD** decode (vendored upstream, already
-SIMD-dispatched) runs ~**410–420 Mpix/s** here — faster than the libdeflate
-ZIP path; there is no second zstd backend to dispatch against.
+scan to the live symbol range.
+
+![PIZ decode before/after the in-tree optimization](perf-piz-decode.svg)
+
+**ZSTD** decode (vendored upstream, already SIMD-dispatched) runs ~**410–420
+Mpix/s** here — faster than the libdeflate ZIP path on identical content; there
+is no second zstd backend to dispatch against.
+
+![ZSTD vs ZIP decode on identical images](perf-zstd-decode.svg)
 
 The two charts below put **libdeflate on/off vs OpenEXR** side by side across the
 deflate family **and HTJ2K** (which has no deflate path, so only the in-tree and


### PR DESCRIPTION
Adds the two remaining charts from this cycle, via the same generator (`doc/gen_perf_charts.py`):

- **`perf-piz-decode.svg`** — in-tree PIZ decode **80.2 → 91.6 Mpix/s (+14%)** from the inline Huffman literal store + tighter canonical-table scan.
- **`perf-zstd-decode.svg`** — **ZSTD vs ZIP(libdeflate)** decode on identical content (6 openexr-images ScanLines re-encoded to each): **zstd 410 vs 272 Mpix/s**.

Both embedded in `doc/performance-vs-openexr.md` next to their prose. Docs/asset only; SVGs validated as well-formed XML and the generator verified deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)