### PR TITLE
exr_jph: fix unused function compiler error

### DIFF
--- a/src/exr_jph.c
+++ b/src/exr_jph.c
@@ -5766,7 +5766,7 @@ static inline exr_result jph_ms_encode64(JphMsEnc *m, uint64_t cwd, int cwd_len)
     return EXR_SUCCESS;
 }
 
-static inline exr_result jph_ms_encode(JphMsEnc *m, uint32_t cwd, int cwd_len) {
+static inline exr_result JPH_MAYBE_UNUSED jph_ms_encode(JphMsEnc *m, uint32_t cwd, int cwd_len) {
     if (cwd_len <= 0) return EXR_SUCCESS;
     return jph_ms_encode64(m, cwd, cwd_len);
 }


### PR DESCRIPTION
Fix a compiler error:

```console
make lib
...
src/exr_jph.c:5769:26: error: unused function 'jph_ms_encode' [-Werror,-Wunused-function]
 5769 | static inline exr_result jph_ms_encode(JphMsEnc *m, uint32_t cwd, int cwd_len) {
      |                          ^~~~~~~~~~~~~
1 error generated.
make: *** [build/exr_jph.o] Error 1
```

OS: macOS 26.5 arm64