### PR TITLE
Fix heap out-of-bounds read (DoS) in PIZ hufUncompress: enforce minimum header length

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -3109,6 +3109,12 @@ static bool hufUncompress(const char compressed[], int nCompressed,
     return false;
   }
 
+  // The Huffman header written by hufCompress() is 20 bytes: im, iM,
+  // tableLength, nBits (readUInt at +0/+4/+8/+12) plus 4 reserved bytes at +16.
+  // Reject inputs too short to contain it; otherwise readUInt(compressed + 12)
+  // reads past the end of the input buffer (heap out-of-bounds read).
+  if (nCompressed < 20) return false;
+
   int im = readUInt(compressed);
   int iM = readUInt(compressed + 4);
   // int tableLength = readUInt (compressed + 8);


### PR DESCRIPTION
This PR fixes a heap out-of-bounds read in the PIZ decompression path.

### Summary

`hufUncompress()` parses a fixed **20-byte** Huffman header from the compressed input but only checks `nCompressed == 0`; it never verifies that at least 20 bytes are available. A crafted PIZ-compressed `.exr` whose Huffman block is shorter than the header and positioned at the end of the input buffer causes `readUInt()` to read past the end of the allocation. This is reachable from the top-level `LoadEXR()` / `LoadEXRFromMemory()` APIs on an untrusted file, and manifests as a heap out-of-bounds **read** (crash / denial of service). It is not an information-disclosure or write primitive (see below).

Affects current `master` (and `v1.0.x`).

### Root cause

`DecompressPiz()` reads a signed `int length` from the chunk and calls `hufUncompress(ptr, length, ...)`. The only bound applied to `length` is an *upper* bound; nothing enforces a minimum. In `hufUncompress`:

```cpp
int im    = readUInt(compressed);      // bytes [0..3]
int iM    = readUInt(compressed + 4);  // bytes [4..7]
int nBits = readUInt(compressed + 12); // bytes [12..15]  <-- OOB when nCompressed < 16
```

`readUInt()` does no bounds checking. The header size is not arbitrary — `hufCompress()` writes exactly 20 bytes:

```cpp
writeUInt(compressed,      im);          // 0..3
writeUInt(compressed + 4,  iM);          // 4..7
writeUInt(compressed + 8,  tableLength); // 8..11
writeUInt(compressed + 12, nBits);       // 12..15
writeUInt(compressed + 16, 0);           // 16..19 (reserved)
```

So a well-formed stream always has ≥ 20 header bytes; anything shorter is malformed and currently over-reads.

### The fix

Add a single minimum-length guard, right after the existing `nCompressed == 0` check:

```cpp
if (nCompressed < 20) return false;
```

Because 20 is exactly what `hufCompress()` emits, this rejects no valid stream.

### Impact (scoped honestly)

Denial of service (out-of-bounds read / crash on a tight, heap-backed input buffer, e.g. `LoadEXRFromMemory`). The over-read bytes only populate the local `im`/`iM`/`nBits`, which feed validation and control flow; the downstream `hufUnpackEncTable` (`p - *pcode >= ni`) and `hufDecode` (`nBits > 8 * (nCompressed - 20)`) are already bounds-checked, so the out-of-bounds bytes do not reach the decoded output. This is therefore DoS-only — not information disclosure and not a write.

### Reproduction

A 345-byte `.exr` reproduces it. The malicious PIZ scanline chunk is 16 bytes at end-of-file: `minNonZero=0x1FFF, maxNonZero=0x0000` (selects the "all zero / no bitmap" path), `length=8`, then `im=0`, `iM=0` (which pass the range gate). `hufUncompress(ptr, 8)` then executes `readUInt(ptr + 12)`, four bytes past the buffer. AddressSanitizer:

```
ERROR: AddressSanitizer: heap-buffer-overflow — READ of size 1
  #0 readUInt        (hufUncompress header parse)
  #1 hufUncompress
  #2 DecompressPiz
  #3 DecodePixelData
  #4 DecodeChunk
  #5 DecodeEXRImage / LoadEXRFromMemory
... located 4 bytes after a 345-byte region
```

(The file-based `LoadEXR(path)` path uses `mmap`, which page-rounds the mapping and can mask the read; the crash is deterministic on the in-memory path and in any embedder that parses from a heap buffer.)
