### PR TITLE
texpipe: KTX2 Zstd supercompression WRITE (tp_ktx2_write_uni_zstd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,30 @@ test/v3/prof_driver
 test/v3/bench_decode
 test/v3/bench_decode_mt
 test/v3/__pycache__/
+
+# test/bench binaries (sanitizer/SIMD variants)
+test/unit/tester-*
+/tester-v2
+/test_debug_deflate
+/test_debug_deflate_simd
+/test_huffman
+/test_huffman_bmi
+/test_multipart
+/test_multipart_debug
+/test_multipart_tiled
+/test_simd
+/test_simd_avx2
+/test_v2_enhanced
+/test_v2_openexr_images
+/test_v2_writer
+
+# vendored zstd distribution: only the wrapper + license are tracked,
+# the rest is the upstream source tree extracted locally to build against.
+/deps/zstd/*
+!/deps/zstd/LICENSE
+!/deps/zstd/README.md
+!/deps/zstd/tinyexr_zstd.c
+!/deps/zstd/tinyexr_zstd.h
+
+# external OpenEXR test-image corpus (cloned locally, not part of this repo)
+/openexr-images/

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CC  ?= gcc
 CXX ?= g++
 EMCC ?= emcc
 EMAR ?= emar
+NODE ?= node
 
 CFLAGS   ?= -O2
 CXXFLAGS ?= -O2 -std=c++11
@@ -498,7 +499,7 @@ TEXPIPE_LIB_SRC = tools/texpipe/src/texpipe.c tools/texpipe/src/texpipe_mip.c \
 TEXPIPE_HDRS = tools/texpipe/include/texpipe.h tools/texpipe/src/texpipe_internal.h
 TEXPIPE_OBJ = $(patsubst tools/texpipe/src/%.c,build/texpipe/%.o,$(TEXPIPE_LIB_SRC))
 
-.PHONY: texpipe texpipe-c11-gate texpipe-test
+.PHONY: texpipe texpipe-c11-gate texpipe-test texpipe-three-ktx2-test
 
 build/texpipe:
 	@mkdir -p build/texpipe
@@ -534,6 +535,24 @@ texpipe-test: resize-lib texcomp tools/texpipe/test/test_texpipe.c $(TEXPIPE_HDR
 	  tools/texpipe/test/test_texpipe.c $(TEXPIPE_LIB_SRC) build/libtir.a \
 	  build/libtexcomp.a -lm -o build/test_texpipe
 	./build/test_texpipe
+
+# Optional browser interoperability gate. This stays outside tools-test because
+# it needs Node, Puppeteer, Three.js and Chrome. Install dependencies in the test
+# directory, or point THREE_KTX2_NODE_ROOT at an existing web project.
+THREE_KTX2_NODE_ROOT ?= tools/texpipe/test/three_ktx2_loader
+
+build/texpipe/three_ktx2_fixture: texpipe \
+  tools/texpipe/test/three_ktx2_loader/generate_fixture.c
+	$(CC) $(V3_CSTD) $(V3_WARN) $(TEXPIPE_INC) -Ideps/zstd -O2 -g \
+	  tools/texpipe/test/three_ktx2_loader/generate_fixture.c \
+	  build/libtexpipe.a build/libtir.a build/libtexcomp.a $(ZSTD_OBJ) \
+	  -pthread -lm -o $@
+
+texpipe-three-ktx2-test: build/texpipe/three_ktx2_fixture
+	./build/texpipe/three_ktx2_fixture build/texpipe/three-ktx2.ktx2
+	THREE_KTX2_NODE_ROOT="$(THREE_KTX2_NODE_ROOT)" \
+	  $(NODE) tools/texpipe/test/three_ktx2_loader/test.mjs \
+	  build/texpipe/three-ktx2.ktx2
 
 # ---- tools/envmap: environment-map projections, SH, spherical gaussians ----
 # Pure C11. Links tir + texcomp + texpipe + libtinyexr3 (CLI does HDR EXR I/O).
@@ -1139,6 +1158,7 @@ help:
 	@echo "make texcomp-astc-arm-smoke - decode our ASTC output with Arm astcenc-native"
 	@echo "make texcomp-astc-arm-gate - self-contained astcenc build + PSNR cross-check (CI gate)"
 	@echo "make texcomp-basis-gate  - Basis Universal transcoder validation (cp basisu_transcoder to deps/basisu/)"
+	@echo "make texpipe-three-ktx2-test - Three.js KTX2Loader browser interop (optional Node/Chrome deps)"
 	@echo "make texcomp-wasm - Emscripten texcomp C API + Node CLI (scalar wasm)"
 	@echo "make texcomp-wasm-simd - Emscripten texcomp C API + Node CLI (-msimd128)"
 	@echo "make bench-compare - tinyexr-vs-OpenEXR codec comparison (needs OpenEXR build)"

--- a/doc/texcomp.md
+++ b/doc/texcomp.md
@@ -36,12 +36,12 @@ one exception, and it is opt-in.
 | EAC R11 / RG11 | 4 / 8 | R / RG | mobile, masks and normal maps |
 | ASTC | 0.9–8 | RGBA | mobile + desktop, variable block size |
 | ASTC HDR | 8 | RGB **HDR** | mobile HDR |
-| `uni` | 8 | RGBA | a UASTC intermediate: encode once, **transcode** per device |
+| `uni` | 8 | RGBA | private ASTC-backed intermediate: encode once, convert per device |
 
-`uni` is the Basis-free transcodable carrier. Encode a texture once, ship it, and
-transcode on load to whatever the device actually has — BC7 on desktop, ASTC or
-ETC2 on mobile — with no re-encode. ASTC 4×4 is a byte copy, because the stored
-blocks *are* valid ASTC blocks.
+`uni` is a texcomp-native carrier. Encode once, then convert on load to the
+device format — BC7 on desktop, ASTC or ETC2 on mobile. ASTC 4×4 is a byte copy
+because the stored blocks are valid ASTC; BC7, BC1 and ETC2 use decode/re-encode
+conversion. It is not the Basis UASTC representation.
 
 ## Containers
 
@@ -184,10 +184,14 @@ wasm module. Nothing is uploaded: every byte stays in the tab.
 ```sh
 make tools-test        # pure-C gates: texcomp, tir, texpipe, envmap
 make tools-test-all    # + the astcenc C++ conformance cross-checks
+make texpipe-three-ktx2-test  # optional Three.js KTX2 browser interop
 ```
 
 `tools-test-all` runs the foreign-block sweeps described above, so a decoder that
 drifts from astcenc, Mesa or bcdec fails the build.
+The standalone browser gate needs Node, Three.js, Puppeteer and Chrome; setup
+and dependency-reuse instructions are in
+`tools/texpipe/test/three_ktx2_loader/README.md`.
 
 ## Status and known gaps
 
@@ -195,3 +199,10 @@ drifts from astcenc, Mesa or bcdec fails the build.
   `tools/texcomp/ASTC_PORT_NOTES.md`.
 - BasisLZ (KTX2 `supercompressionScheme = 1`) is not implemented, and will not be
   until it can be validated against Basis's own transcoder.
+- Raw `uni` blocks are valid ASTC 4×4 blocks but are not the Basis UASTC wire
+  representation. The default KTX2 wrapper is therefore a TinyEXR-private
+  carrier and must be read by texpipe. Pass `TP_UNI_ASTC_KTX2` to the raw or
+  scheme-2 writer for a standards-defined ASTC KTX2 that interoperates with
+  external consumers such as Three.js `KTX2Loader`. The texcomp-native
+  `--basis` codebook is separate from BasisLZ and does not change the scheme-1
+  limitation.

--- a/tools/texcomp/NOTICE.md
+++ b/tools/texcomp/NOTICE.md
@@ -68,10 +68,13 @@ headers.
   follows the *concept* pioneered by Basis Universal / UASTC — a canonical
   single-subset block re-packed cheaply to the device's GPU format. It is a
   texcomp-native intermediate and is **not** the Basis `.basis`/UASTC bitstream.
-  Its optional codebook supercompression (`--basis`) is a BasisLZ-*style*
+  Every stored block is valid ASTC 4x4, so `TP_UNI_ASTC_KTX2` can write a
+  standard ASTC KTX2 without transcoding; the default wrapper remains private.
+- Its optional codebook supercompression (`--basis`) is a BasisLZ-*style*
   endpoint/selector deduplication with RDO; it is **not** the Basis ETC1S codec
-  and does not emit KTX2 `supercompressionScheme=1` (BasisLZ) — the KTX2 output
-  uses Zstd (scheme 2) with the codebook as an inner pre-transform.
+  and does not emit KTX2
+  `supercompressionScheme=1`; KTX2 output uses Zstd (scheme 2), optionally with
+  the codebook as an inner pre-transform.
 
 ### QuickBC7 / etcpak
 - BC7 quick-mode heuristics and API naming derive from a pure-C11 port of the

--- a/tools/texcomp/src/texcomp_cli.c
+++ b/tools/texcomp/src/texcomp_cli.c
@@ -580,9 +580,9 @@ static int build_mips(const uint8_t *base, uint32_t w, uint32_t h,
     return n;
 }
 
-/* Write uni levels as a KTX2 (vkFormat=UNDEFINED, supercompressionScheme=2/Zstd).
+/* Write uni levels as standard ASTC 4x4 KTX2 with Zstd supercompression.
  * Each mip level is Zstd-compressed independently; data is packed smallest-first
- * (KTX2 convention). Our loader identifies the file by vkFormat==0 && scheme==2. */
+ * (KTX2 convention). Uni blocks are valid ASTC; they are not Basis UASTC. */
 static tc_result write_uni_ktx2(const char *path, uint8_t *const uni[],
                                 const size_t uni_sizes[], const uint32_t lw[],
                                 const uint32_t lh[], int nlevels, int basis,
@@ -596,7 +596,7 @@ static tc_result write_uni_ktx2(const char *path, uint8_t *const uni[],
     int l;
     tc_result r = TC_SUCCESS;
     (void)lh;
-    (void)basis; (void)rdo; /* Basis codebook layer removed (incompatible with UASTC block layout). */
+    (void)basis; (void)rdo; /* Codebook layer removed from the private uni layout. */
     for (l = 0; l < nlevels; ++l) {
         const uint8_t *src = uni[l];
         size_t src_size = uni_sizes[l], bound;
@@ -615,7 +615,7 @@ static tc_result write_uni_ktx2(const char *path, uint8_t *const uni[],
     ktx = (uint8_t *)calloc(1, total);
     if (!ktx) { r = TC_ERROR_OUT_OF_MEMORY; goto done; }
     memcpy(ktx, id, 12);
-    xbc7_put32(ktx + 12, 0u);              /* vkFormat = UNDEFINED */
+    xbc7_put32(ktx + 12, 157u);            /* ASTC_4x4_UNORM_BLOCK */
     xbc7_put32(ktx + 16, 1u);              /* typeSize */
     xbc7_put32(ktx + 20, lw[0]);
     xbc7_put32(ktx + 24, lh[0]);
@@ -632,13 +632,14 @@ static tc_result write_uni_ktx2(const char *path, uint8_t *const uni[],
     }
     xbc7_put32(ktx + dfd_off, 44u);
     xbc7_put32(ktx + dfd_off + 8, 2u | (40u << 16));
-    ktx[dfd_off + 12] = 166u; ktx[dfd_off + 13] = 1u; ktx[dfd_off + 14] = 1u;
+    ktx[dfd_off + 12] = 162u; ktx[dfd_off + 13] = 1u; ktx[dfd_off + 14] = 1u;
     ktx[dfd_off + 16] = 3u; ktx[dfd_off + 17] = 3u; ktx[dfd_off + 20] = 16u;
     ktx[dfd_off + 30] = 127u; xbc7_put32(ktx + dfd_off + 40, 0xffffffffu);
     for (l = 0; l < nlevels; ++l) memcpy(ktx + loff[l], comp[l], clen[l]);
     r = write_file(path, ktx, total);
     if (r == TC_SUCCESS)
-        printf("wrote %s (uni UASTC KTX2, %d mip levels, Zstd, %zu bytes)\n", path, nlevels, total);
+        printf("wrote %s (uni as ASTC 4x4 KTX2, %d mip levels, Zstd, %zu bytes)\n",
+               path, nlevels, total);
 done:
     for (l = 0; l < nlevels; ++l) { free(comp[l]); free(bbuf[l]); }
     free(ktx);
@@ -654,7 +655,9 @@ static int read_uni_ktx2(const char *path, uint8_t *uni[], size_t uni_sizes[],
     uint32_t pw, ph;
     int nlevels, l;
     if (!buf) return -1;
-    if (fsz < 80u || xbc7_get32(buf + 12) != 0u || xbc7_get32(buf + 44) != 2u) {
+    if (fsz < 80u ||
+        (xbc7_get32(buf + 12) != 157u && xbc7_get32(buf + 12) != 158u) ||
+        xbc7_get32(buf + 44) != 2u) {
         free(buf); return -1;
     }
     nlevels = (int)xbc7_get32(buf + 40);
@@ -768,7 +771,9 @@ static int encode_one(const char *in, const char *out,
             if (cat) { p = cat; for (l = 0; l < nl; ++l) { memcpy(p, blocks[l], bsz[l]); p += bsz[l]; } tr = write_file(out, cat, total); }
             else tr = TC_ERROR_OUT_OF_MEMORY;
         }
-        if (tr == TC_SUCCESS) printf("transcoded UASTC %s -> %s (%s, %d level%s, %zu bytes)\n", in, out, format, nl, nl == 1 ? "" : "s", total);
+        if (tr == TC_SUCCESS)
+            printf("converted uni %s -> %s (%s, %d level%s, %zu bytes)\n", in,
+                   out, format, nl, nl == 1 ? "" : "s", total);
         else fprintf(stderr, "texcomp: uni transcode failed\n");
         for (l = 0; l < nl; ++l) { free(blocks[l]); free(ulev[l]); }
         free(cat);
@@ -990,9 +995,9 @@ static void usage(void) {
             "        color axis, keep-best (off by default; ~+0.09 dB, ~1.7x slower).\n"
             "  --hdr-alpha: for --format astc_hdr on an EXR, encode the alpha\n"
             "        channel too (ASTC HDR CEM 15); default is RGB-only.\n"
-            "  uni: universal transcodable intermediate (UASTC block format).\n"
+            "  uni: private universal intermediate made of valid ASTC 4x4 blocks.\n"
             "        `--format uni -o x.uni` (raw, level 0) or `-o x.ktx2` (KTX2,\n"
-            "        full mip chain, Zstd-supercompressed). Transcode all levels\n"
+            "        standard ASTC KTX2 mip chain, Zstd-supercompressed). Convert levels\n"
             "        with `-i x.{uni,ktx2} -o out.bin --format bc7|bc1|astc|etc2`.\n"
             "        ASTC 4x4 is a byte-copy (the stored blocks are valid ASTC);\n"
             "        bc7/bc1/etc2 go through decode+re-encode.\n"

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -385,6 +385,36 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
                             const uint32_t *level_h, int num_levels,
                             uint8_t *out, size_t out_size, size_t *written);
 
+/* Zstd compressor callbacks -- the write-side counterpart of
+ * tp_zstd_decompress_fn. `zbound` returns the worst-case compressed size for
+ * `src_size` (wrap ZSTD_compressBound); `zenc` compresses and returns the bytes
+ * written, or 0 on error (wrap ZSTD_compress). As on the read side, the library
+ * carries no zstd dependency -- the host supplies these. */
+typedef size_t (*tp_zstd_bound_fn)(void *user, size_t src_size);
+typedef size_t (*tp_zstd_compress_fn)(void *user, uint8_t *dst, size_t dst_cap,
+                                      const uint8_t *src, size_t src_size);
+
+/* tp_ktx2_write_uni, but Zstd-supercompressed (supercompressionScheme = 2) --
+ * the form real KTX2/UASTC assets ship in on disk (block data typically packs to
+ * a fraction of its raw size). Each level is compressed independently so a reader
+ * can inflate them one at a time; read it back with tp_ktx2_read_zstd.
+ *
+ * The output size is not known until the levels are compressed, so unlike
+ * tp_ktx2_write_uni the buffer is *allocated* with `a` (NULL = malloc) and
+ * returned via *out / *out_size; release it with tp_free(a, *out).
+ *
+ * Level rules match tp_ktx2_write_uni: only level_w[0] / level_h[0] reach the
+ * header, levels 1.. must be the standard halving pyramid, and uni_sizes[l] must
+ * be the exact block payload for level l (the reader pins uncompressedByteLength
+ * to it). */
+tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound,
+                                 tp_zstd_compress_fn zenc, void *user,
+                                 const uint8_t *const *uni_levels,
+                                 const size_t *uni_sizes,
+                                 const uint32_t *level_w,
+                                 const uint32_t *level_h, int num_levels,
+                                 uint8_t **out, size_t *out_size);
+
 /* ===========================================================================
  * Leaf helpers (also the Phase 1 test surface)
  * ========================================================================= */

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -401,7 +401,8 @@ typedef size_t (*tp_zstd_compress_fn)(void *user, uint8_t *dst, size_t dst_cap,
  *
  * The output size is not known until the levels are compressed, so unlike
  * tp_ktx2_write_uni the buffer is *allocated* with `a` (NULL = malloc) and
- * returned via *out / *out_size; release it with tp_free(a, *out).
+ * returned via *out / *out_size; release it with tp_free(a, *out). On failure
+ * *out / *out_size are cleared to NULL / 0.
  *
  * Level rules match tp_ktx2_write_uni: only level_w[0] / level_h[0] reach the
  * header, levels 1.. must be the standard halving pyramid, and uni_sizes[l] must

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -369,20 +369,35 @@ tp_result tp_ktx2_decode_slice_rgbaf(const tp_ktx2_image *img, int level,
                                      int layer, int face, float *out_rgba,
                                      size_t out_size);
 
+/* What the uni DFD should say about the payload. Neither can be inferred from
+ * the block bytes, and both are wrong by default if left unset: a consumer that
+ * honours the DFD (libktx, glTF KHR_texture_basisu loaders) would take sRGB
+ * albedo for linear-light data, and would transcode an RGBA texture into an
+ * alpha-less format. Pass TP_UNI_SRGB for non-linear (albedo/colour) textures
+ * and TP_UNI_ALPHA when the source alpha channel carries information. */
+#define TP_UNI_SRGB 0x1u  /* transfer = sRGB rather than linear   */
+#define TP_UNI_ALPHA 0x2u /* channelType = UASTC_RGBA rather than RGB */
+
 /* Serialize pre-encoded uni (UASTC) mip levels as a KTX2 (vkFormat = UNDEFINED,
  * supercompressionScheme = 0, KHR_DF UASTC descriptor). This is the Basis-free
  * transcodable carrier: the reader reports is_uni = 1 and a consumer transcodes
  * per device with tc_uni_transcode_{bc7,bc1,astc,etc2} or decodes with
  * tc_uni_decompress_rgba8. `uni_levels[l]`/`uni_sizes[l]` are the level-l uni
- * bytes (from tc_uni_compress_rgba8), level 0 = largest. Only level_w[0] /
- * level_h[0] reach the header: levels 1..num_levels-1 must be the standard
- * halving pyramid (max(1, w >> l)), which is how the reader re-derives them.
+ * bytes (from tc_uni_compress_rgba8), level 0 = largest.
+ *
+ * Only the base dimensions are passed: every other level's size is derived as
+ * max(1, base >> l), which is how the reader re-derives them, so uni_sizes[l]
+ * must be exactly the 4x4x16B block payload for that level. num_levels may not
+ * exceed the pyramid base_w x base_h actually has, and neither dimension may
+ * exceed TP_KTX2_MAX_DIM -- the reader refuses all of these, so writing one
+ * would only produce a file that cannot be read back.
+ *
  * tp_ktx2_uni_size returns the required output size, or 0 if num_levels is out
  * of range or the level sizes would overflow the layout. */
 size_t tp_ktx2_uni_size(const size_t *uni_sizes, int num_levels);
 tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
-                            const size_t *uni_sizes, const uint32_t *level_w,
-                            const uint32_t *level_h, int num_levels,
+                            const size_t *uni_sizes, uint32_t base_w,
+                            uint32_t base_h, int num_levels, uint32_t flags,
                             uint8_t *out, size_t out_size, size_t *written);
 
 /* Zstd compressor callbacks -- the write-side counterpart of
@@ -404,16 +419,12 @@ typedef size_t (*tp_zstd_compress_fn)(void *user, uint8_t *dst, size_t dst_cap,
  * returned via *out / *out_size; release it with tp_free(a, *out). On failure
  * *out / *out_size are cleared to NULL / 0.
  *
- * Level rules match tp_ktx2_write_uni: only level_w[0] / level_h[0] reach the
- * header, levels 1.. must be the standard halving pyramid, and uni_sizes[l] must
- * be the exact block payload for level l (the reader pins uncompressedByteLength
- * to it). */
+ * Level, dimension and flag rules are exactly tp_ktx2_write_uni's. */
 tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound,
                                  tp_zstd_compress_fn zenc, void *user,
                                  const uint8_t *const *uni_levels,
-                                 const size_t *uni_sizes,
-                                 const uint32_t *level_w,
-                                 const uint32_t *level_h, int num_levels,
+                                 const size_t *uni_sizes, uint32_t base_w,
+                                 uint32_t base_h, int num_levels, uint32_t flags,
                                  uint8_t **out, size_t *out_size);
 
 /* ===========================================================================

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -275,10 +275,10 @@ typedef struct tp_ktx2_level {
 typedef struct tp_ktx2_image {
     uint32_t vk_format;      /* 0 = UNDEFINED (the tinyexr uni intermediate)   */
     tp_codec codec;          /* mapped block codec (valid only when !is_uni)   */
-    int is_uni;              /* 1 = uni/UASTC transcodable intermediate        */
+    int is_uni;              /* 1 = TinyEXR-private uni intermediate           */
     int is_hdr;
     int srgb;                /* for is_uni, read back from the DFD transfer fn  */
-    int has_alpha;           /* uni only: DFD says UASTC_RGBA (TP_UNI_ALPHA)    */
+    int has_alpha;           /* uni only: private DFD carries TP_UNI_ALPHA      */
     int is_signed;           /* BC6H sf16 / BC5 snorm (vs the unsigned variant) */
     int block_w, block_h, block_bytes;
     uint32_t width, height;  /* base (level 0) dimensions                      */
@@ -299,9 +299,9 @@ typedef struct tp_ktx2_image {
 /* Parse a KTX2 blob (identifier + header + level index + DFD). Fills `out` with
  * pointers into `data` (no allocation). Supports supercompressionScheme 0 only
  * (Zstd/BasisLZ return TP_ERROR_UNSUPPORTED — use tp_ktx2_read_zstd for Zstd).
- * vk_format == 0 is interpreted as the uni intermediate (is_uni = 1). Returns
- * TP_ERROR_INVALID_ARGUMENT on a bad identifier / out-of-bounds level index,
- * TP_ERROR_UNSUPPORTED for an unrecognized vk_format or supercompression. */
+ * vk_format == 0 with texpipe's private UNSPECIFIED-model DFD is interpreted as
+ * uni (is_uni = 1). Basis UASTC and other undefined-format payloads return
+ * TP_ERROR_UNSUPPORTED rather than being misdecoded. */
 tp_result tp_ktx2_read(const uint8_t *data, size_t size, tp_ktx2_image *out);
 
 /* Zstd decompressor callback: decompress `src_size` bytes at `src` into `dst`
@@ -370,21 +370,26 @@ tp_result tp_ktx2_decode_slice_rgbaf(const tp_ktx2_image *img, int level,
                                      int layer, int face, float *out_rgba,
                                      size_t out_size);
 
-/* What the uni DFD should say about the payload. Neither can be inferred from
- * the block bytes, and both are wrong by default if left unset: a consumer that
- * honours the DFD (libktx, glTF KHR_texture_basisu loaders) would take sRGB
- * albedo for linear-light data, and would transcode an RGBA texture into an
- * alpha-less format. Pass TP_UNI_SRGB for non-linear (albedo/colour) textures
- * and TP_UNI_ALPHA when the source alpha channel carries information. */
-#define TP_UNI_SRGB 0x1u  /* transfer = sRGB rather than linear   */
-#define TP_UNI_ALPHA 0x2u /* channelType = UASTC_RGBA rather than RGB */
+/* KTX2 flags for pre-encoded uni levels. The private carrier's colour space and
+ * alpha use cannot be inferred from the block bytes, so pass TP_UNI_SRGB for
+ * non-linear (albedo/colour) textures and TP_UNI_ALPHA when alpha carries
+ * information. TP_UNI_ASTC_KTX2 selects a standards-defined ASTC 4x4 KTX2
+ * carrier instead: the uni bytes are valid ASTC blocks, while they are not the
+ * Basis UASTC wire representation. In ASTC mode TP_UNI_ALPHA has no effect on
+ * the KTX2 descriptor because the ASTC format always carries RGBA. */
+#define TP_UNI_SRGB 0x1u       /* transfer = sRGB rather than linear */
+#define TP_UNI_ALPHA 0x2u      /* private carrier: RGBA rather than RGB */
+#define TP_UNI_ASTC_KTX2 0x4u  /* standard ASTC 4x4 KTX2 carrier */
 
-/* Serialize pre-encoded uni (UASTC) mip levels as a KTX2 (vkFormat = UNDEFINED,
- * supercompressionScheme = 0, KHR_DF UASTC descriptor). This is the Basis-free
- * transcodable carrier: the reader reports is_uni = 1 and a consumer transcodes
- * per device with tc_uni_transcode_{bc7,bc1,astc,etc2} or decodes with
- * tc_uni_decompress_rgba8. `uni_levels[l]`/`uni_sizes[l]` are the level-l uni
- * bytes (from tc_uni_compress_rgba8), level 0 = largest.
+/* Serialize pre-encoded uni mip levels as KTX2. By default this writes the
+ * TinyEXR-private carrier (vkFormat = UNDEFINED): the reader reports is_uni = 1
+ * and callers use tc_uni_transcode_{bc7,bc1,astc,etc2} or
+ * tc_uni_decompress_rgba8. It must not be passed to a Basis UASTC consumer.
+ *
+ * With TP_UNI_ASTC_KTX2, the writer emits a standard ASTC 4x4 VkFormat and DFD.
+ * External KTX2 consumers can then upload/decode it as ASTC; texpipe's reader
+ * reports codec = TP_CODEC_ASTC and is_uni = 0. `uni_levels[l]`/`uni_sizes[l]`
+ * are the level-l bytes from tc_uni_compress_rgba8, level 0 = largest.
  *
  * Only the base dimensions are used: every other level's size is derived as
  * max(1, base >> l), which is how the reader re-derives them, so uni_sizes[l]
@@ -406,10 +411,8 @@ tp_result tp_ktx2_write_uni_ex(const uint8_t *const *uni_levels,
  * element [0] of level_w/level_h was ever read, and flags = 0 means the DFD says
  * linear, no alpha -- what this function always emitted.
  *
- * Prefer tp_ktx2_write_uni_ex: a uni file has no vkFormat, so unless you pass
- * TP_UNI_SRGB / TP_UNI_ALPHA the DFD cannot tell a consumer that your texture is
- * sRGB or that its alpha means anything, and it will be uploaded as linear and
- * transcoded to an alpha-less format. */
+ * Prefer tp_ktx2_write_uni_ex so colour/alpha metadata can be supplied, or so
+ * TP_UNI_ASTC_KTX2 can request the interoperable standard ASTC carrier. */
 tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
                             const size_t *uni_sizes, const uint32_t *level_w,
                             const uint32_t *level_h, int num_levels,
@@ -424,10 +427,9 @@ typedef size_t (*tp_zstd_bound_fn)(void *user, size_t src_size);
 typedef size_t (*tp_zstd_compress_fn)(void *user, uint8_t *dst, size_t dst_cap,
                                       const uint8_t *src, size_t src_size);
 
-/* tp_ktx2_write_uni, but Zstd-supercompressed (supercompressionScheme = 2) --
- * the form real KTX2/UASTC assets ship in on disk (block data typically packs to
- * a fraction of its raw size). Each level is compressed independently so a reader
- * can inflate them one at a time; read it back with tp_ktx2_read_zstd.
+/* tp_ktx2_write_uni_ex, but Zstd-supercompressed
+ * (supercompressionScheme = 2). Each level is compressed independently so a
+ * reader can inflate them one at a time; read it back with tp_ktx2_read_zstd.
  *
  * The output size is not known until the levels are compressed, so unlike
  * tp_ktx2_write_uni the buffer is *allocated* with `a` (NULL = malloc) and

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -277,7 +277,8 @@ typedef struct tp_ktx2_image {
     tp_codec codec;          /* mapped block codec (valid only when !is_uni)   */
     int is_uni;              /* 1 = uni/UASTC transcodable intermediate        */
     int is_hdr;
-    int srgb;
+    int srgb;                /* for is_uni, read back from the DFD transfer fn  */
+    int has_alpha;           /* uni only: DFD says UASTC_RGBA (TP_UNI_ALPHA)    */
     int is_signed;           /* BC6H sf16 / BC5 snorm (vs the unsigned variant) */
     int block_w, block_h, block_bytes;
     uint32_t width, height;  /* base (level 0) dimensions                      */

--- a/tools/texpipe/include/texpipe.h
+++ b/tools/texpipe/include/texpipe.h
@@ -386,7 +386,7 @@ tp_result tp_ktx2_decode_slice_rgbaf(const tp_ktx2_image *img, int level,
  * tc_uni_decompress_rgba8. `uni_levels[l]`/`uni_sizes[l]` are the level-l uni
  * bytes (from tc_uni_compress_rgba8), level 0 = largest.
  *
- * Only the base dimensions are passed: every other level's size is derived as
+ * Only the base dimensions are used: every other level's size is derived as
  * max(1, base >> l), which is how the reader re-derives them, so uni_sizes[l]
  * must be exactly the 4x4x16B block payload for that level. num_levels may not
  * exceed the pyramid base_w x base_h actually has, and neither dimension may
@@ -396,9 +396,23 @@ tp_result tp_ktx2_decode_slice_rgbaf(const tp_ktx2_image *img, int level,
  * tp_ktx2_uni_size returns the required output size, or 0 if num_levels is out
  * of range or the level sizes would overflow the layout. */
 size_t tp_ktx2_uni_size(const size_t *uni_sizes, int num_levels);
+tp_result tp_ktx2_write_uni_ex(const uint8_t *const *uni_levels,
+                               const size_t *uni_sizes, uint32_t base_w,
+                               uint32_t base_h, int num_levels, uint32_t flags,
+                               uint8_t *out, size_t out_size, size_t *written);
+
+/* The pre-flags form, kept so existing callers keep compiling. Equivalent to
+ * tp_ktx2_write_uni_ex(..., level_w[0], level_h[0], num_levels, 0, ...): only
+ * element [0] of level_w/level_h was ever read, and flags = 0 means the DFD says
+ * linear, no alpha -- what this function always emitted.
+ *
+ * Prefer tp_ktx2_write_uni_ex: a uni file has no vkFormat, so unless you pass
+ * TP_UNI_SRGB / TP_UNI_ALPHA the DFD cannot tell a consumer that your texture is
+ * sRGB or that its alpha means anything, and it will be uploaded as linear and
+ * transcoded to an alpha-less format. */
 tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
-                            const size_t *uni_sizes, uint32_t base_w,
-                            uint32_t base_h, int num_levels, uint32_t flags,
+                            const size_t *uni_sizes, const uint32_t *level_w,
+                            const uint32_t *level_h, int num_levels,
                             uint8_t *out, size_t out_size, size_t *written);
 
 /* Zstd compressor callbacks -- the write-side counterpart of

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -721,6 +721,91 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
     return TP_SUCCESS;
 }
 
+tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound,
+                                 tp_zstd_compress_fn zenc, void *user,
+                                 const uint8_t *const *uni_levels,
+                                 const size_t *uni_sizes,
+                                 const uint32_t *level_w,
+                                 const uint32_t *level_h, int num_levels,
+                                 uint8_t **out, size_t *out_size) {
+    uint8_t *comp[TP_KTX2_MAX_LEVELS];
+    size_t clen[TP_KTX2_MAX_LEVELS];
+    uint64_t loff[TP_KTX2_MAX_LEVELS];
+    const size_t smax = (size_t)-1;
+    size_t dfd_off, cursor, total;
+    uint8_t *buf = NULL;
+    tp_result r = TP_SUCCESS;
+    int l;
+
+    if (!zbound || !zenc || !uni_levels || !uni_sizes || !level_w || !level_h ||
+        !out || !out_size)
+        return TP_ERROR_INVALID_ARGUMENT;
+    if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
+        return TP_ERROR_INVALID_ARGUMENT;
+    for (l = 0; l < num_levels; ++l) comp[l] = NULL;
+
+    /* Compress each level independently, so a reader can inflate one at a time. */
+    for (l = 0; l < num_levels; ++l) {
+        size_t bound;
+        if (uni_sizes[l] == 0) { r = TP_ERROR_INVALID_ARGUMENT; goto done; }
+        bound = zbound(user, uni_sizes[l]);
+        if (bound == 0) { r = TP_ERROR_UNSUPPORTED; goto done; }
+        comp[l] = (uint8_t *)tp_alloc(a, bound);
+        if (!comp[l]) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
+        clen[l] = zenc(user, comp[l], bound, uni_levels[l], uni_sizes[l]);
+        if (clen[l] == 0 || clen[l] > bound) { r = TP_ERROR_UNSUPPORTED; goto done; }
+    }
+
+    /* Layout: header + level index + DFD, then the compressed levels packed
+     * smallest-first. Supercompressed levels carry no mip padding. */
+    dfd_off = 80u + (size_t)num_levels * 24u;
+    cursor = dfd_off + 44u;
+    for (l = num_levels - 1; l >= 0; --l) {
+        if (clen[l] > smax - cursor) { r = TP_ERROR_INVALID_ARGUMENT; goto done; }
+        loff[l] = cursor;
+        cursor += clen[l];
+    }
+    total = cursor;
+
+    buf = (uint8_t *)tp_alloc(a, total);
+    if (!buf) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
+    memset(buf, 0, total);
+    memcpy(buf, tp_ktx2_id, 12);
+    tp_wr_u32(buf + 12, 0u);        /* vkFormat = UNDEFINED (uni)          */
+    tp_wr_u32(buf + 16, 1u);        /* typeSize                            */
+    tp_wr_u32(buf + 20, level_w[0]);
+    tp_wr_u32(buf + 24, level_h[0]);
+    tp_wr_u32(buf + 28, 0u);        /* pixelDepth                          */
+    tp_wr_u32(buf + 32, 0u);        /* layerCount                          */
+    tp_wr_u32(buf + 36, 1u);        /* faceCount                           */
+    tp_wr_u32(buf + 40, (uint32_t)num_levels);
+    tp_wr_u32(buf + 44, 2u);        /* supercompressionScheme = Zstd       */
+    tp_wr_u32(buf + 48, (uint32_t)dfd_off);
+    tp_wr_u32(buf + 52, 44u);
+    tp_wr_u32(buf + 56, 0u);        /* kvdByteOffset                       */
+    tp_wr_u32(buf + 60, 0u);        /* kvdByteLength                       */
+    tp_wr_u64(buf + 64, 0u);        /* sgdByteOffset                       */
+    tp_wr_u64(buf + 72, 0u);        /* sgdByteLength                       */
+    for (l = 0; l < num_levels; ++l) {
+        uint8_t *e = buf + 80u + (size_t)l * 24u;
+        tp_wr_u64(e + 0, loff[l]);
+        tp_wr_u64(e + 8, (uint64_t)clen[l]);       /* byteLength (compressed) */
+        tp_wr_u64(e + 16, (uint64_t)uni_sizes[l]); /* uncompressedByteLength  */
+    }
+    tp_write_uni_dfd(buf + dfd_off);
+    for (l = 0; l < num_levels; ++l)
+        memcpy(buf + (size_t)loff[l], comp[l], clen[l]);
+
+    *out = buf;
+    *out_size = total;
+    buf = NULL;
+
+done:
+    for (l = 0; l < num_levels; ++l) tp_dealloc(a, comp[l]);
+    if (buf) tp_dealloc(a, buf);
+    return r;
+}
+
 /* ---- KTX2 texture arrays (layerCount) ---- */
 
 static size_t tp_ktx2_array_layout(const tp_blocks *layers, int num_layers,

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -382,8 +382,11 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
 
     if (size < 80u + (size_t)nlev * 24u) return TP_ERROR_INVALID_ARGUMENT;
 
-    /* The DFD is not parsed (vkFormat carries everything we need), but a file
-     * claiming one outside the blob is malformed. */
+    /* For a real vkFormat the DFD is redundant (the format carries everything),
+     * but a uni file has no format, so the uni branch below reads its transfer
+     * and channelType. This bound is what makes those reads safe: with dfd_len
+     * >= 44 the whole descriptor is inside the blob. A file claiming a DFD
+     * outside it is malformed either way. */
     if (dfd_len != 0u &&
         ((uint64_t)dfd_off + (uint64_t)dfd_len > (uint64_t)size ||
          dfd_off < 80u + (uint64_t)nlev * 24u))

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -457,14 +457,20 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
             size_t got;
             if (!w) w = 1u;
             if (!h) h = 1u;
+            /* Both failures below happen with levels 0..l-1 already pointing
+             * into `owned`. Clear the image after freeing it: a caller that
+             * inspects it on error must not find dangling pointers, and _owned
+             * is still NULL here so tp_ktx2_image_free could not save them. */
             if (off > size || clen > (uint64_t)size - off) {
                 tp_dealloc(a, owned);
+                memset(out, 0, sizeof(*out));
                 return TP_ERROR_INVALID_ARGUMENT;
             }
             got = zdec(user, owned + cursor, (size_t)ulen[l], data + (size_t)off,
                        (size_t)clen);
             if (got != (size_t)ulen[l]) {
                 tp_dealloc(a, owned);
+                memset(out, 0, sizeof(*out));
                 return TP_ERROR_INVALID_ARGUMENT;
             }
             out->levels[l].data = owned + cursor;
@@ -807,11 +813,10 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
                                  const size_t *uni_sizes, uint32_t base_w,
                                  uint32_t base_h, int num_levels, uint32_t flags,
                                  uint8_t **out, size_t *out_size) {
-    uint8_t *comp[TP_KTX2_MAX_LEVELS];
     size_t clen[TP_KTX2_MAX_LEVELS];
     uint64_t loff[TP_KTX2_MAX_LEVELS];
     const size_t smax = (size_t)-1;
-    size_t cursor, total;
+    size_t head, cap, cursor;
     uint8_t *buf = NULL;
     tp_result r;
     int l;
@@ -823,44 +828,54 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
     *out_size = 0;
     r = tp_uni_check(uni_levels, uni_sizes, base_w, base_h, num_levels, flags);
     if (!TP_OK(r)) return r;
-    for (l = 0; l < num_levels; ++l) comp[l] = NULL;
-
-    /* Compress each level independently, so a reader can inflate one at a time. */
-    for (l = 0; l < num_levels; ++l) {
-        size_t bound = zbound(user, uni_sizes[l]);
-        if (bound == 0) { r = TP_ERROR_UNSUPPORTED; goto done; }
-        comp[l] = (uint8_t *)tp_alloc(a, bound);
-        if (!comp[l]) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
-        clen[l] = zenc(user, comp[l], bound, uni_levels[l], uni_sizes[l]);
-        if (clen[l] == 0 || clen[l] > bound) { r = TP_ERROR_UNSUPPORTED; goto done; }
-    }
 
     /* Layout: header + level index + DFD, then the compressed levels packed
      * smallest-first. Supercompressed levels carry no mip padding -- KTX2 sets
-     * required_alignment = 1 when supercompressionScheme != 0. */
-    cursor = 80u + (size_t)num_levels * 24u + 44u;
+     * required_alignment = 1 when supercompressionScheme != 0.
+     *
+     * Size the buffer for the worst case (every level incompressible) and
+     * compress straight into it at a running cursor, rather than into per-level
+     * scratch that is then copied in. The compressed sizes are not known up
+     * front, so the buffer ends up larger than the file: *out_size is the real
+     * length. This keeps peak memory at one buffer instead of the scratch and
+     * the output at once, which is what the 32-bit wasm heap has room for. */
+    head = 80u + (size_t)num_levels * 24u + 44u;
+    cap = head;
+    for (l = 0; l < num_levels; ++l) {
+        size_t bound = zbound(user, uni_sizes[l]);
+        if (bound == 0) return TP_ERROR_UNSUPPORTED;
+        if (bound > smax - cap) return TP_ERROR_INVALID_ARGUMENT;
+        cap += bound;
+    }
+    buf = (uint8_t *)tp_alloc(a, cap);
+    if (!buf) return TP_ERROR_OUT_OF_MEMORY;
+
+    /* Compress each level independently, so a reader can inflate one at a time.
+     * Smallest-first, so the cursor walks the levels in the order they are
+     * stored. Each level still gets at least its own zbound of room: what is
+     * left of `cap` here is the sum of the bounds of this level and every level
+     * not yet written. */
+    cursor = head;
     for (l = num_levels - 1; l >= 0; --l) {
-        if (clen[l] > smax - cursor) { r = TP_ERROR_INVALID_ARGUMENT; goto done; }
         loff[l] = cursor;
+        clen[l] = zenc(user, buf + cursor, cap - cursor, uni_levels[l],
+                       uni_sizes[l]);
+        if (clen[l] == 0 || clen[l] > cap - cursor) {
+            r = TP_ERROR_UNSUPPORTED;
+            goto done;
+        }
         cursor += clen[l];
     }
-    total = cursor;
 
-    buf = (uint8_t *)tp_alloc(a, total);
-    if (!buf) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
-    /* No memset: with no padding anywhere in this layout, the emit below plus
-     * the level copies write every byte of `total`. */
+    /* Nothing below `head` has been touched yet, and the levels wrote every byte
+     * from `head` to `cursor` -- so no memset is needed anywhere. */
     tp_ktx2_uni_emit(buf, base_w, base_h, num_levels, 2u, flags, loff, clen,
                      uni_sizes);
-    for (l = 0; l < num_levels; ++l)
-        memcpy(buf + (size_t)loff[l], comp[l], clen[l]);
-
     *out = buf;
-    *out_size = total;
-    buf = NULL;
+    *out_size = cursor;
+    return TP_SUCCESS;
 
 done:
-    for (l = 0; l < num_levels; ++l) tp_dealloc(a, comp[l]);
     tp_dealloc(a, buf);
     return r;
 }

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -639,20 +639,37 @@ tp_result tp_ktx2_decode_slice_rgba8(const tp_ktx2_image *img, int level,
 
 /* ---- uni (UASTC) KTX2 writer: vkFormat=UNDEFINED, supercompression=0 ---- */
 
-/* KHR_DF UASTC descriptor (44 bytes), matching the uni-in-KTX2 convention. */
-static void tp_write_uni_dfd(uint8_t *p) {
+#define TP_KDF_MODEL_UASTC 166u
+#define TP_KDF_PRIMARIES_UNSPECIFIED 0u
+#define TP_KDF_CHANNEL_UASTC_RGB 0u
+#define TP_KDF_CHANNEL_UASTC_RGBA 3u
+#define TP_UNI_FLAGS_ALL (TP_UNI_SRGB | TP_UNI_ALPHA)
+
+/* KHR_DF UASTC descriptor (44 bytes), matching the uni-in-KTX2 convention.
+ * `flags` is the caller's TP_UNI_SRGB / TP_UNI_ALPHA: neither is recoverable
+ * from the block bytes, and both are what a DFD-honouring consumer keys off to
+ * decide sRGB decode and whether to transcode into a format that has alpha. */
+static void tp_write_uni_dfd(uint8_t *p, uint32_t flags) {
     memset(p, 0, 44);
     tp_wr_u32(p + 0, 44u);                 /* dfdTotalSize */
     tp_wr_u32(p + 8, 2u | (40u << 16));    /* version | descriptorBlockSize */
-    p[12] = 166u;                          /* KHR_DF_MODEL_UASTC */
-    p[13] = 1u;                            /* primaries BT709 */
-    p[14] = 1u;                            /* transfer LINEAR */
+    p[12] = (uint8_t)TP_KDF_MODEL_UASTC;
+    /* The glTF KHR_texture_basisu profile that `ktx validate` enforces admits
+     * exactly two colour pairings: BT709 primaries with sRGB transfer, or
+     * UNSPECIFIED primaries with linear. Non-colour uni data (normal, roughness)
+     * has no meaningful primaries, so pair linear with UNSPECIFIED. */
+    p[13] = (uint8_t)((flags & TP_UNI_SRGB) ? TP_KDF_PRIMARIES_BT709
+                                            : TP_KDF_PRIMARIES_UNSPECIFIED);
+    p[14] = (uint8_t)((flags & TP_UNI_SRGB) ? TP_KDF_TRANSFER_SRGB
+                                            : TP_KDF_TRANSFER_LINEAR);
     p[16] = 3u; p[17] = 3u;                /* texelBlockDimension = 4x4 */
     /* The pre-deflation block size, kept as-is even under supercompression:
      * KTX2 2.0.4 dropped the old "bytesPlane must be 0 if supercompressed" rule
      * and now requires the real value (0 merely warns as deprecated). */
     p[20] = 16u;                           /* bytesPlane0 */
     p[30] = 127u;                          /* sample bitLength (128 bits) */
+    p[31] = (uint8_t)((flags & TP_UNI_ALPHA) ? TP_KDF_CHANNEL_UASTC_RGBA
+                                             : TP_KDF_CHANNEL_UASTC_RGB);
     tp_wr_u32(p + 40, 0xffffffffu);        /* sampleUpper */
 }
 
@@ -694,46 +711,90 @@ size_t tp_ktx2_uni_size(const size_t *sizes, int num_levels) {
     return tp_ktx2_uni_layout(sizes, num_levels, NULL);
 }
 
-tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
-                            const size_t *uni_sizes, const uint32_t *level_w,
-                            const uint32_t *level_h, int num_levels,
-                            uint8_t *out, size_t out_size, size_t *written) {
-    uint64_t loff[TP_KTX2_MAX_LEVELS];
-    size_t need, dfd_off;
+/* Everything both uni writers must reject. Each rule exists because the reader
+ * (or the KTX2 spec) refuses the result, so writing one would only produce a
+ * file that cannot be loaded back -- a silent failure at asset-build time that
+ * surfaces much later. Shared so the two writers cannot drift apart. */
+static tp_result tp_uni_check(const uint8_t *const *uni_levels,
+                              const size_t *uni_sizes, uint32_t base_w,
+                              uint32_t base_h, int num_levels, uint32_t flags) {
     int l;
-    if (!uni_levels || !uni_sizes || !level_w || !level_h || !out)
-        return TP_ERROR_INVALID_ARGUMENT;
+    if (!uni_levels || !uni_sizes) return TP_ERROR_INVALID_ARGUMENT;
     if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
         return TP_ERROR_INVALID_ARGUMENT;
+    if (flags & ~TP_UNI_FLAGS_ALL) return TP_ERROR_INVALID_ARGUMENT;
+    /* The reader refuses dimensions past TP_KTX2_MAX_DIM. */
+    if (base_w == 0u || base_h == 0u || base_w > (uint32_t)TP_KTX2_MAX_DIM ||
+        base_h > (uint32_t)TP_KTX2_MAX_DIM)
+        return TP_ERROR_INVALID_ARGUMENT;
+    /* levelCount past the pyramid the base dimensions imply is invalid KTX2:
+     * the surplus levels all clamp to 1x1, and a loader that trusts levelCount
+     * would bind mips that do not exist. */
+    if (num_levels > tp_level_count((int)base_w, (int)base_h, 0))
+        return TP_ERROR_INVALID_ARGUMENT;
+    /* Level sizes must be exactly the block payload the reader derives from the
+     * base dimensions -- the scheme-2 reader pins uncompressedByteLength to it,
+     * and the scheme-0 reader rejects anything shorter as truncated. */
+    for (l = 0; l < num_levels; ++l)
+        if (!uni_levels[l] ||
+            (uint64_t)uni_sizes[l] != tp_uni_level_expected(base_w, base_h, l))
+            return TP_ERROR_INVALID_ARGUMENT;
+    return TP_SUCCESS;
+}
+
+/* Header + level index + DFD, i.e. everything before the level payloads. The
+ * two writers differ only in `scheme` and in the byteLength column: raw levels
+ * store their own size there, supercompressed ones the compressed size. */
+static void tp_ktx2_uni_emit(uint8_t *buf, uint32_t base_w, uint32_t base_h,
+                             int num_levels, uint32_t scheme, uint32_t flags,
+                             const uint64_t *loff, const size_t *byte_len,
+                             const size_t *uncompressed_len) {
+    size_t dfd_off = 80u + (size_t)num_levels * 24u;
+    int l;
+    memcpy(buf, tp_ktx2_id, 12);
+    tp_wr_u32(buf + 12, 0u);        /* vkFormat = UNDEFINED (uni) */
+    tp_wr_u32(buf + 16, 1u);        /* typeSize                   */
+    tp_wr_u32(buf + 20, base_w);
+    tp_wr_u32(buf + 24, base_h);
+    tp_wr_u32(buf + 28, 0u);        /* pixelDepth                 */
+    tp_wr_u32(buf + 32, 0u);        /* layerCount                 */
+    tp_wr_u32(buf + 36, 1u);        /* faceCount                  */
+    tp_wr_u32(buf + 40, (uint32_t)num_levels);
+    tp_wr_u32(buf + 44, scheme);
+    tp_wr_u32(buf + 48, (uint32_t)dfd_off);
+    tp_wr_u32(buf + 52, 44u);
+    tp_wr_u32(buf + 56, 0u);        /* kvdByteOffset              */
+    tp_wr_u32(buf + 60, 0u);        /* kvdByteLength              */
+    tp_wr_u64(buf + 64, 0u);        /* sgdByteOffset              */
+    tp_wr_u64(buf + 72, 0u);        /* sgdByteLength              */
+    for (l = 0; l < num_levels; ++l) {
+        uint8_t *e = buf + 80u + (size_t)l * 24u;
+        tp_wr_u64(e + 0, loff[l]);
+        tp_wr_u64(e + 8, (uint64_t)byte_len[l]);
+        tp_wr_u64(e + 16, (uint64_t)uncompressed_len[l]);
+    }
+    tp_write_uni_dfd(buf + dfd_off, flags);
+}
+
+tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
+                            const size_t *uni_sizes, uint32_t base_w,
+                            uint32_t base_h, int num_levels, uint32_t flags,
+                            uint8_t *out, size_t out_size, size_t *written) {
+    uint64_t loff[TP_KTX2_MAX_LEVELS];
+    size_t need;
+    tp_result r;
+    int l;
+    if (!out) return TP_ERROR_INVALID_ARGUMENT;
+    r = tp_uni_check(uni_levels, uni_sizes, base_w, base_h, num_levels, flags);
+    if (!TP_OK(r)) return r;
     need = tp_ktx2_uni_layout(uni_sizes, num_levels, loff);
     if (need == 0u) return TP_ERROR_INVALID_ARGUMENT; /* layout overflowed */
     if (out_size < need) return TP_ERROR_INVALID_ARGUMENT;
+    /* Unlike the supercompressed layout, this one aligns each level to 16, so
+     * the padding between them has to be zeroed. */
     memset(out, 0, need);
-
-    memcpy(out, tp_ktx2_id, 12);
-    tp_wr_u32(out + 12, 0u);                      /* vkFormat = UNDEFINED */
-    tp_wr_u32(out + 16, 1u);                      /* typeSize */
-    tp_wr_u32(out + 20, level_w[0]);
-    tp_wr_u32(out + 24, level_h[0]);
-    tp_wr_u32(out + 28, 0u);                      /* pixelDepth */
-    tp_wr_u32(out + 32, 0u);                      /* layerCount */
-    tp_wr_u32(out + 36, 1u);                      /* faceCount */
-    tp_wr_u32(out + 40, (uint32_t)num_levels);
-    tp_wr_u32(out + 44, 0u);                      /* supercompressionScheme */
-    dfd_off = 80u + (size_t)num_levels * 24u;
-    tp_wr_u32(out + 48, (uint32_t)dfd_off);       /* dfdByteOffset */
-    tp_wr_u32(out + 52, 44u);                     /* dfdByteLength */
-    tp_wr_u32(out + 56, 0u);                      /* kvdByteOffset */
-    tp_wr_u32(out + 60, 0u);                      /* kvdByteLength */
-    tp_wr_u64(out + 64, 0u);                      /* sgdByteOffset */
-    tp_wr_u64(out + 72, 0u);                      /* sgdByteLength */
-    for (l = 0; l < num_levels; ++l) {
-        uint8_t *e = out + 80u + (size_t)l * 24u;
-        tp_wr_u64(e + 0, loff[l]);
-        tp_wr_u64(e + 8, (uint64_t)uni_sizes[l]);
-        tp_wr_u64(e + 16, (uint64_t)uni_sizes[l]); /* uncompressedByteLength */
-    }
-    tp_write_uni_dfd(out + dfd_off);
+    tp_ktx2_uni_emit(out, base_w, base_h, num_levels, 0u, flags, loff, uni_sizes,
+                     uni_sizes);
     for (l = 0; l < num_levels; ++l)
         memcpy(out + (size_t)loff[l], uni_levels[l], uni_sizes[l]);
     if (written) *written = need;
@@ -743,54 +804,30 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
 tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound,
                                  tp_zstd_compress_fn zenc, void *user,
                                  const uint8_t *const *uni_levels,
-                                 const size_t *uni_sizes,
-                                 const uint32_t *level_w,
-                                 const uint32_t *level_h, int num_levels,
+                                 const size_t *uni_sizes, uint32_t base_w,
+                                 uint32_t base_h, int num_levels, uint32_t flags,
                                  uint8_t **out, size_t *out_size) {
     uint8_t *comp[TP_KTX2_MAX_LEVELS];
     size_t clen[TP_KTX2_MAX_LEVELS];
     uint64_t loff[TP_KTX2_MAX_LEVELS];
     const size_t smax = (size_t)-1;
-    size_t dfd_off, cursor, total;
+    size_t cursor, total;
     uint8_t *buf = NULL;
-    tp_result r = TP_SUCCESS;
+    tp_result r;
     int l;
 
-    if (!zbound || !zenc || !uni_levels || !uni_sizes || !level_w || !level_h ||
-        !out || !out_size)
-        return TP_ERROR_INVALID_ARGUMENT;
+    if (!zbound || !zenc || !out || !out_size) return TP_ERROR_INVALID_ARGUMENT;
     /* Cleared before any other rejection: the contract is that a failed call
      * leaves nothing for the caller to free. */
     *out = NULL;
     *out_size = 0;
-    if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
-        return TP_ERROR_INVALID_ARGUMENT;
-    /* The reader refuses dimensions past TP_KTX2_MAX_DIM, so writing them would
-     * only produce a file we cannot read back. */
-    if (level_w[0] == 0u || level_h[0] == 0u ||
-        level_w[0] > (uint32_t)TP_KTX2_MAX_DIM ||
-        level_h[0] > (uint32_t)TP_KTX2_MAX_DIM)
-        return TP_ERROR_INVALID_ARGUMENT;
-    /* levelCount past the pyramid the base dimensions imply is invalid KTX2:
-     * the extra levels would all clamp to 1x1 and a loader that trusts
-     * levelCount would bind mips that do not exist. */
-    if (num_levels > tp_level_count((int)level_w[0], (int)level_h[0], 0))
-        return TP_ERROR_INVALID_ARGUMENT;
+    r = tp_uni_check(uni_levels, uni_sizes, base_w, base_h, num_levels, flags);
+    if (!TP_OK(r)) return r;
     for (l = 0; l < num_levels; ++l) comp[l] = NULL;
-
-    /* A scheme-2 reader pins uncompressedByteLength to the exact block payload
-     * implied by the base dimensions, so a level whose size disagrees would
-     * produce a file our own reader rejects. Refuse it here instead. */
-    for (l = 0; l < num_levels; ++l)
-        if (!uni_levels[l] ||
-            (uint64_t)uni_sizes[l] !=
-                tp_uni_level_expected(level_w[0], level_h[0], l))
-            return TP_ERROR_INVALID_ARGUMENT;
 
     /* Compress each level independently, so a reader can inflate one at a time. */
     for (l = 0; l < num_levels; ++l) {
-        size_t bound;
-        bound = zbound(user, uni_sizes[l]);
+        size_t bound = zbound(user, uni_sizes[l]);
         if (bound == 0) { r = TP_ERROR_UNSUPPORTED; goto done; }
         comp[l] = (uint8_t *)tp_alloc(a, bound);
         if (!comp[l]) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
@@ -799,9 +836,9 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
     }
 
     /* Layout: header + level index + DFD, then the compressed levels packed
-     * smallest-first. Supercompressed levels carry no mip padding. */
-    dfd_off = 80u + (size_t)num_levels * 24u;
-    cursor = dfd_off + 44u;
+     * smallest-first. Supercompressed levels carry no mip padding -- KTX2 sets
+     * required_alignment = 1 when supercompressionScheme != 0. */
+    cursor = 80u + (size_t)num_levels * 24u + 44u;
     for (l = num_levels - 1; l >= 0; --l) {
         if (clen[l] > smax - cursor) { r = TP_ERROR_INVALID_ARGUMENT; goto done; }
         loff[l] = cursor;
@@ -811,30 +848,10 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
 
     buf = (uint8_t *)tp_alloc(a, total);
     if (!buf) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
-    memset(buf, 0, total);
-    memcpy(buf, tp_ktx2_id, 12);
-    tp_wr_u32(buf + 12, 0u);        /* vkFormat = UNDEFINED (uni)          */
-    tp_wr_u32(buf + 16, 1u);        /* typeSize                            */
-    tp_wr_u32(buf + 20, level_w[0]);
-    tp_wr_u32(buf + 24, level_h[0]);
-    tp_wr_u32(buf + 28, 0u);        /* pixelDepth                          */
-    tp_wr_u32(buf + 32, 0u);        /* layerCount                          */
-    tp_wr_u32(buf + 36, 1u);        /* faceCount                           */
-    tp_wr_u32(buf + 40, (uint32_t)num_levels);
-    tp_wr_u32(buf + 44, 2u);        /* supercompressionScheme = Zstd       */
-    tp_wr_u32(buf + 48, (uint32_t)dfd_off);
-    tp_wr_u32(buf + 52, 44u);
-    tp_wr_u32(buf + 56, 0u);        /* kvdByteOffset                       */
-    tp_wr_u32(buf + 60, 0u);        /* kvdByteLength                       */
-    tp_wr_u64(buf + 64, 0u);        /* sgdByteOffset                       */
-    tp_wr_u64(buf + 72, 0u);        /* sgdByteLength                       */
-    for (l = 0; l < num_levels; ++l) {
-        uint8_t *e = buf + 80u + (size_t)l * 24u;
-        tp_wr_u64(e + 0, loff[l]);
-        tp_wr_u64(e + 8, (uint64_t)clen[l]);       /* byteLength (compressed) */
-        tp_wr_u64(e + 16, (uint64_t)uni_sizes[l]); /* uncompressedByteLength  */
-    }
-    tp_write_uni_dfd(buf + dfd_off);
+    /* No memset: with no padding anywhere in this layout, the emit below plus
+     * the level copies write every byte of `total`. */
+    tp_ktx2_uni_emit(buf, base_w, base_h, num_levels, 2u, flags, loff, clen,
+                     uni_sizes);
     for (l = 0; l < num_levels; ++l)
         memcpy(buf + (size_t)loff[l], comp[l], clen[l]);
 
@@ -844,7 +861,7 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
 
 done:
     for (l = 0; l < num_levels; ++l) tp_dealloc(a, comp[l]);
-    if (buf) tp_dealloc(a, buf);
+    tp_dealloc(a, buf);
     return r;
 }
 

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -109,9 +109,14 @@ tp_result tp_dds_write(const tp_blocks *b, const tp_options *opt, uint8_t *out,
 #define TP_KDF_MODEL_BC7 134u
 #define TP_KDF_MODEL_ETC2 161u
 #define TP_KDF_MODEL_ASTC 162u
+#define TP_KDF_MODEL_UASTC 166u
+#define TP_KDF_PRIMARIES_UNSPECIFIED 0u
 #define TP_KDF_PRIMARIES_BT709 1u
 #define TP_KDF_TRANSFER_LINEAR 1u
 #define TP_KDF_TRANSFER_SRGB 2u
+/* Sample channelType ids for the UASTC model (Khronos khr_df.h). */
+#define TP_KDF_CHANNEL_UASTC_RGB 0u
+#define TP_KDF_CHANNEL_UASTC_RGBA 3u
 
 static uint32_t tp_kdf_model(tp_codec codec) {
     switch (codec) {
@@ -170,6 +175,13 @@ static size_t tp_align_up(size_t v, size_t a) {
     return (v + (a - 1)) / a * a;
 }
 
+/* The dimension range the KTX2 reader accepts. A writer that goes outside it
+ * only produces files the library itself refuses to load. */
+static int tp_ktx2_dims_ok(uint32_t w, uint32_t h) {
+    return w != 0u && h != 0u && w <= (uint32_t)TP_KTX2_MAX_DIM &&
+           h <= (uint32_t)TP_KTX2_MAX_DIM;
+}
+
 /* Byte length of one mip level = sum of all faces at that level. */
 static size_t tp_ktx2_level_len(const tp_blocks *b, int level) {
     size_t total = 0;
@@ -216,6 +228,8 @@ tp_result tp_ktx2_write(const tp_blocks *b, const tp_options *opt, uint8_t *out,
     int ll, face;
     if (!b || !opt || !out) return TP_ERROR_INVALID_ARGUMENT;
     if (b->num_levels > 32) return TP_ERROR_UNSUPPORTED;
+    if (!tp_ktx2_dims_ok(b->blk[0].width, b->blk[0].height))
+        return TP_ERROR_UNSUPPORTED;
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u)
         return TP_ERROR_UNSUPPORTED;
     need = tp_ktx2_layout(b, &d, level_off, level_len);
@@ -326,9 +340,12 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
     uint32_t dfd_off, dfd_len, kvd_off, kvd_len;
     int nlev, l;
     if (!data || !out) return TP_ERROR_INVALID_ARGUMENT;
+    /* Cleared before the identifier check, not after: every other failure path
+     * hands back a zeroed struct, and a caller that inspects `out` on error must
+     * not get stack garbage from these two returns either. */
+    memset(out, 0, sizeof(*out));
     if (size < 80u || memcmp(data, tp_ktx2_id, 12) != 0)
         return TP_ERROR_INVALID_ARGUMENT;
-    memset(out, 0, sizeof(*out));
 
     vk = tp_rd_u32(data + 12);
     out->width = tp_rd_u32(data + 20);
@@ -388,6 +405,17 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
         out->block_w = 4;
         out->block_h = 4;
         out->block_bytes = 16;
+        /* A uni file carries no vkFormat, so the DFD is the only place the sRGB
+         * and alpha facts live -- and they are exactly what a consumer needs to
+         * pick an upload format and an alpha-capable transcode target. Parse the
+         * two bytes we write; a DFD too short to hold them leaves the defaults
+         * (linear, no alpha), which is what an absent DFD means anyway. */
+        if (dfd_len >= 44u) {
+            uint8_t transfer = data[(size_t)dfd_off + 14];
+            uint8_t channels = data[(size_t)dfd_off + 31] & 0x0fu;
+            out->srgb = (transfer == (uint8_t)TP_KDF_TRANSFER_SRGB);
+            out->has_alpha = (channels == (uint8_t)TP_KDF_CHANNEL_UASTC_RGBA);
+        }
     } else {
         tp_codec_desc d;
         tp_codec c;
@@ -645,10 +673,6 @@ tp_result tp_ktx2_decode_slice_rgba8(const tp_ktx2_image *img, int level,
 
 /* ---- uni (UASTC) KTX2 writer: vkFormat=UNDEFINED, supercompression=0 ---- */
 
-#define TP_KDF_MODEL_UASTC 166u
-#define TP_KDF_PRIMARIES_UNSPECIFIED 0u
-#define TP_KDF_CHANNEL_UASTC_RGB 0u
-#define TP_KDF_CHANNEL_UASTC_RGBA 3u
 #define TP_UNI_FLAGS_ALL (TP_UNI_SRGB | TP_UNI_ALPHA)
 
 /* KHR_DF UASTC descriptor (44 bytes), matching the uni-in-KTX2 convention.
@@ -730,10 +754,7 @@ static tp_result tp_uni_check(const uint8_t *const *uni_levels,
     if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
         return TP_ERROR_INVALID_ARGUMENT;
     if (flags & ~TP_UNI_FLAGS_ALL) return TP_ERROR_INVALID_ARGUMENT;
-    /* The reader refuses dimensions past TP_KTX2_MAX_DIM. */
-    if (base_w == 0u || base_h == 0u || base_w > (uint32_t)TP_KTX2_MAX_DIM ||
-        base_h > (uint32_t)TP_KTX2_MAX_DIM)
-        return TP_ERROR_INVALID_ARGUMENT;
+    if (!tp_ktx2_dims_ok(base_w, base_h)) return TP_ERROR_INVALID_ARGUMENT;
     /* levelCount past the pyramid the base dimensions imply is invalid KTX2:
      * the surplus levels all clamp to 1x1, and a loader that trusts levelCount
      * would bind mips that do not exist. */
@@ -946,10 +967,27 @@ tp_result tp_write_ktx2_array(const tp_blocks *layers, int num_layers,
     nlev = layers[0].num_levels;
     nface = layers[0].num_faces;
     if (nlev > 32) return TP_ERROR_UNSUPPORTED;
-    for (li = 1; li < num_layers; ++li)
+    /* The reader refuses layerCount past this, so writing more would only make a
+     * file that cannot be loaded back. */
+    if (num_layers > TP_KTX2_MAX_LAYERS) return TP_ERROR_UNSUPPORTED;
+    if (!tp_ktx2_dims_ok(layers[0].blk[0].width, layers[0].blk[0].height))
+        return TP_ERROR_UNSUPPORTED;
+    for (li = 1; li < num_layers; ++li) {
+        int k;
         if (layers[li].num_levels != nlev || layers[li].num_faces != nface ||
             layers[li].codec != layers[0].codec)
             return TP_ERROR_INVALID_ARGUMENT;
+        /* Every level's byte length is computed from layers[0] and multiplied by
+         * num_layers, but the payload loop below copies each layer's own
+         * blk[].size. A layer that disagrees on dimensions therefore memcpy's
+         * past the end of `out`. Require the layers to be block-for-block
+         * identical in shape -- which is what a KTX2 array is. */
+        for (k = 0; k < nface * nlev; ++k)
+            if (layers[li].blk[k].size != layers[0].blk[k].size ||
+                layers[li].blk[k].width != layers[0].blk[k].width ||
+                layers[li].blk[k].height != layers[0].blk[k].height)
+                return TP_ERROR_INVALID_ARGUMENT;
+    }
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u)
         return TP_ERROR_UNSUPPORTED;
     need = tp_ktx2_array_layout(layers, num_layers, &d, level_off, level_len);

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -648,9 +648,20 @@ static void tp_write_uni_dfd(uint8_t *p) {
     p[13] = 1u;                            /* primaries BT709 */
     p[14] = 1u;                            /* transfer LINEAR */
     p[16] = 3u; p[17] = 3u;                /* texelBlockDimension = 4x4 */
+    /* The pre-deflation block size, kept as-is even under supercompression:
+     * KTX2 2.0.4 dropped the old "bytesPlane must be 0 if supercompressed" rule
+     * and now requires the real value (0 merely warns as deprecated). */
     p[20] = 16u;                           /* bytesPlane0 */
     p[30] = 127u;                          /* sample bitLength (128 bits) */
     tp_wr_u32(p + 40, 0xffffffffu);        /* sampleUpper */
+}
+
+/* Levels in the full pyramid for w0 x h0: floor(log2(max(w0, h0))) + 1. */
+static int tp_uni_max_levels(uint32_t w0, uint32_t h0) {
+    uint32_t m = w0 > h0 ? w0 : h0;
+    int n = 1;
+    while (m > 1u) { m >>= 1; ++n; }
+    return n;
 }
 
 /* Tightly-packed 4x4x16B payload of uni level `l`, sized off the base dimensions
@@ -751,18 +762,32 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
     if (!zbound || !zenc || !uni_levels || !uni_sizes || !level_w || !level_h ||
         !out || !out_size)
         return TP_ERROR_INVALID_ARGUMENT;
-    if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
-        return TP_ERROR_INVALID_ARGUMENT;
-    if (level_w[0] == 0u || level_h[0] == 0u) return TP_ERROR_INVALID_ARGUMENT;
+    /* Cleared before any other rejection: the contract is that a failed call
+     * leaves nothing for the caller to free. */
     *out = NULL;
     *out_size = 0;
+    if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
+        return TP_ERROR_INVALID_ARGUMENT;
+    /* The reader refuses dimensions past TP_KTX2_MAX_DIM, so writing them would
+     * only produce a file we cannot read back (and would wrap the level-size
+     * math below on a 32-bit size_t). */
+    if (level_w[0] == 0u || level_h[0] == 0u ||
+        level_w[0] > (uint32_t)TP_KTX2_MAX_DIM ||
+        level_h[0] > (uint32_t)TP_KTX2_MAX_DIM)
+        return TP_ERROR_INVALID_ARGUMENT;
+    /* levelCount past the pyramid the base dimensions imply is invalid KTX2:
+     * the extra levels would all clamp to 1x1 and a loader that trusts
+     * levelCount would bind mips that do not exist. */
+    if (num_levels > tp_uni_max_levels(level_w[0], level_h[0]))
+        return TP_ERROR_INVALID_ARGUMENT;
     for (l = 0; l < num_levels; ++l) comp[l] = NULL;
 
     /* A scheme-2 reader pins uncompressedByteLength to the exact block payload
      * implied by the base dimensions, so a level whose size disagrees would
      * produce a file our own reader rejects. Refuse it here instead. */
     for (l = 0; l < num_levels; ++l)
-        if (uni_sizes[l] != tp_uni_level_expected(level_w[0], level_h[0], l))
+        if (!uni_levels[l] ||
+            uni_sizes[l] != tp_uni_level_expected(level_w[0], level_h[0], l))
             return TP_ERROR_INVALID_ARGUMENT;
 
     /* Compress each level independently, so a reader can inflate one at a time. */

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -841,10 +841,10 @@ static void tp_ktx2_uni_emit(uint8_t *buf, uint32_t base_w, uint32_t base_h,
     tp_write_uni_dfd(buf + dfd_off, flags);
 }
 
-tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
-                            const size_t *uni_sizes, uint32_t base_w,
-                            uint32_t base_h, int num_levels, uint32_t flags,
-                            uint8_t *out, size_t out_size, size_t *written) {
+tp_result tp_ktx2_write_uni_ex(const uint8_t *const *uni_levels,
+                               const size_t *uni_sizes, uint32_t base_w,
+                               uint32_t base_h, int num_levels, uint32_t flags,
+                               uint8_t *out, size_t out_size, size_t *written) {
     /* Zeroed because tp_ktx2_uni_layout fills only [0, num_levels) and the
      * compiler cannot see that across the call into tp_ktx2_uni_emit. */
     uint64_t loff[TP_KTX2_MAX_LEVELS] = {0};
@@ -877,13 +877,24 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
     return TP_SUCCESS;
 }
 
+/* Pre-flags compatibility form. Only level_w[0]/level_h[0] were ever read, and
+ * flags = 0 reproduces the DFD this used to emit (linear, no alpha). */
+tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
+                            const size_t *uni_sizes, const uint32_t *level_w,
+                            const uint32_t *level_h, int num_levels,
+                            uint8_t *out, size_t out_size, size_t *written) {
+    if (!level_w || !level_h) return TP_ERROR_INVALID_ARGUMENT;
+    return tp_ktx2_write_uni_ex(uni_levels, uni_sizes, level_w[0], level_h[0],
+                                num_levels, 0u, out, out_size, written);
+}
+
 tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound,
                                  tp_zstd_compress_fn zenc, void *user,
                                  const uint8_t *const *uni_levels,
                                  const size_t *uni_sizes, uint32_t base_w,
                                  uint32_t base_h, int num_levels, uint32_t flags,
                                  uint8_t **out, size_t *out_size) {
-    /* Zeroed for the same reason as in tp_ktx2_write_uni: the compiler cannot
+    /* Zeroed for the same reason as in tp_ktx2_write_uni_ex: the compiler cannot
      * see that the loop below fills exactly [0, num_levels) before both arrays
      * are handed to tp_ktx2_uni_emit. */
     size_t clen[TP_KTX2_MAX_LEVELS] = {0};

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -182,18 +182,40 @@ static int tp_ktx2_dims_ok(uint32_t w, uint32_t h) {
            h <= (uint32_t)TP_KTX2_MAX_DIM;
 }
 
-/* Byte length of one mip level = sum of all faces at that level. */
+/* The block shape both KTX2 block writers require of a tp_blocks. Checked before
+ * anything reads blk[0]: a zeroed tp_blocks (what a tp_compress_chain that
+ * failed leaves behind) has num_levels == 0 and a NULL blk, and must produce an
+ * error rather than a NULL dereference. */
+static int tp_blocks_shape_ok(const tp_blocks *b, const tp_options *opt) {
+    if (!b->blk || b->num_levels < 1 || b->num_levels > 32) return 0;
+    if (b->num_faces != 1 && b->num_faces != 6) return 0;
+    /* The vkFormat and DFD come from opt->codec but the payload bytes come from
+     * b: if they disagree, the file says BC1 over BC7 blocks and every reader
+     * decodes garbage from it. */
+    if (b->codec != opt->codec) return 0;
+    return tp_ktx2_dims_ok(b->blk[0].width, b->blk[0].height);
+}
+
+/* Byte length of one mip level = sum of all faces at that level. SIZE_MAX marks
+ * an overflow: the sizes are caller data, and on a 32-bit size_t (wasm) six
+ * faces of a large level can wrap, which would under-size the buffer the payload
+ * loop then memcpys into. */
+#define TP_SIZE_OVF ((size_t)-1)
 static size_t tp_ktx2_level_len(const tp_blocks *b, int level) {
     size_t total = 0;
     int face;
-    for (face = 0; face < b->num_faces; ++face)
-        total += b->blk[face * b->num_levels + level].size;
+    for (face = 0; face < b->num_faces; ++face) {
+        size_t s = b->blk[face * b->num_levels + level].size;
+        if (s > TP_SIZE_OVF - total) return TP_SIZE_OVF;
+        total += s;
+    }
     return total;
 }
 
 /* Compute the file layout: data region base + per-level absolute offsets
  * (levels stored smallest-first, aligned to the texel block size). Returns the
- * total file size; fills level_off/level_len if non-NULL. */
+ * total file size, or 0 if the layout overflows size_t; fills
+ * level_off/level_len if non-NULL. */
 static size_t tp_ktx2_layout(const tp_blocks *b, const tp_codec_desc *d,
                              uint64_t *level_off, uint64_t *level_len) {
     size_t idx_bytes = (size_t)b->num_levels * 24u;
@@ -203,7 +225,10 @@ static size_t tp_ktx2_layout(const tp_blocks *b, const tp_codec_desc *d,
     if (align < 4u) align = 4u;
     for (ll = b->num_levels - 1; ll >= 0; --ll) {
         size_t len = tp_ktx2_level_len(b, ll);
+        if (len == TP_SIZE_OVF) return 0;
+        if (cursor > TP_SIZE_OVF - (align - 1u)) return 0;
         cursor = tp_align_up(cursor, align);
+        if (len > TP_SIZE_OVF - cursor) return 0;
         if (level_off) level_off[ll] = cursor;
         if (level_len) level_len[ll] = len;
         cursor += len;
@@ -213,7 +238,7 @@ static size_t tp_ktx2_layout(const tp_blocks *b, const tp_codec_desc *d,
 
 size_t tp_ktx2_size(const tp_blocks *b, const tp_options *opt) {
     tp_codec_desc d;
-    if (!b || !opt) return 0;
+    if (!b || !opt || !tp_blocks_shape_ok(b, opt)) return 0;
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u) return 0;
     return tp_ktx2_layout(b, &d, NULL, NULL);
 }
@@ -227,12 +252,11 @@ tp_result tp_ktx2_write(const tp_blocks *b, const tp_options *opt, uint8_t *out,
     size_t need, idx_base, dfd_off;
     int ll, face;
     if (!b || !opt || !out) return TP_ERROR_INVALID_ARGUMENT;
-    if (b->num_levels > 32) return TP_ERROR_UNSUPPORTED;
-    if (!tp_ktx2_dims_ok(b->blk[0].width, b->blk[0].height))
-        return TP_ERROR_UNSUPPORTED;
+    if (!tp_blocks_shape_ok(b, opt)) return TP_ERROR_UNSUPPORTED;
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u)
         return TP_ERROR_UNSUPPORTED;
     need = tp_ktx2_layout(b, &d, level_off, level_len);
+    if (need == 0u) return TP_ERROR_INVALID_ARGUMENT; /* layout overflowed */
     if (out_size < need) return TP_ERROR_INVALID_ARGUMENT;
     memset(out, 0, need);
 
@@ -326,23 +350,21 @@ tp_result tp_ktx2_read(const uint8_t *data, size_t size, tp_ktx2_image *out) {
     return tp_ktx2_read_zstd(data, size, NULL, NULL, NULL, out);
 }
 
+/* Zeroes the whole image, not just the owned block: the level pointers alias
+ * either that block or the caller's source buffer, so after this call none of
+ * them are safe to follow and the struct must not look usable. */
 void tp_ktx2_image_free(const tir_allocator *a, tp_ktx2_image *img) {
-    if (img && img->_owned) {
-        tp_dealloc(a, img->_owned);
-        img->_owned = NULL;
-    }
+    if (!img) return;
+    tp_dealloc(a, img->_owned); /* NULL for a zero-copy scheme-0 read */
+    memset(img, 0, sizeof(*img));
 }
 
-tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
-                            const tir_allocator *a, tp_zstd_decompress_fn zdec,
-                            void *user, tp_ktx2_image *out) {
+static tp_result tp_ktx2_parse(const uint8_t *data, size_t size,
+                               const tir_allocator *a, tp_zstd_decompress_fn zdec,
+                               void *user, tp_ktx2_image *out) {
     uint32_t vk, layer_count, face_count, level_count, scheme;
     uint32_t dfd_off, dfd_len, kvd_off, kvd_len;
     int nlev, l;
-    if (!data || !out) return TP_ERROR_INVALID_ARGUMENT;
-    /* Cleared before the identifier check, not after: every other failure path
-     * hands back a zeroed struct, and a caller that inspects `out` on error must
-     * not get stack garbage from these two returns either. */
     memset(out, 0, sizeof(*out));
     if (size < 80u || memcmp(data, tp_ktx2_id, 12) != 0)
         return TP_ERROR_INVALID_ARGUMENT;
@@ -413,7 +435,8 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
          * pick an upload format and an alpha-capable transcode target. Parse the
          * two bytes we write; a DFD too short to hold them leaves the defaults
          * (linear, no alpha), which is what an absent DFD means anyway. */
-        if (dfd_len >= 44u) {
+        if (dfd_len >= 44u &&
+            data[(size_t)dfd_off + 12] == (uint8_t)TP_KDF_MODEL_UASTC) {
             uint8_t transfer = data[(size_t)dfd_off + 14];
             uint8_t channels = data[(size_t)dfd_off + 31] & 0x0fu;
             out->srgb = (transfer == (uint8_t)TP_KDF_TRANSFER_SRGB);
@@ -488,20 +511,16 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
             size_t got;
             if (!w) w = 1u;
             if (!h) h = 1u;
-            /* Both failures below happen with levels 0..l-1 already pointing
-             * into `owned`. Clear the image after freeing it: a caller that
-             * inspects it on error must not find dangling pointers, and _owned
-             * is still NULL here so tp_ktx2_image_free could not save them. */
+            /* `owned` must be released here (the caller gets no image to free on
+             * failure); the wrapper zeroes the half-filled level pointers. */
             if (off > size || clen > (uint64_t)size - off) {
                 tp_dealloc(a, owned);
-                memset(out, 0, sizeof(*out));
                 return TP_ERROR_INVALID_ARGUMENT;
             }
             got = zdec(user, owned + cursor, (size_t)ulen[l], data + (size_t)off,
                        (size_t)clen);
             if (got != (size_t)ulen[l]) {
                 tp_dealloc(a, owned);
-                memset(out, 0, sizeof(*out));
                 return TP_ERROR_INVALID_ARGUMENT;
             }
             out->levels[l].data = owned + cursor;
@@ -513,6 +532,21 @@ tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
         out->_owned = owned;
         return TP_SUCCESS;
     }
+}
+
+/* Every failure hands back a zeroed image -- no half-filled header, no level
+ * pointers into a buffer that was freed on the way out. tp_ktx2_parse bails from
+ * a dozen places, so the guarantee lives here rather than at each of them.
+ * Note `out` must not already hold a loaded image: reading into a live one
+ * overwrites its _owned pointer. Call tp_ktx2_image_free first. */
+tp_result tp_ktx2_read_zstd(const uint8_t *data, size_t size,
+                            const tir_allocator *a, tp_zstd_decompress_fn zdec,
+                            void *user, tp_ktx2_image *out) {
+    tp_result r;
+    if (!data || !out) return TP_ERROR_INVALID_ARGUMENT;
+    r = tp_ktx2_parse(data, size, a, zdec, user, out);
+    if (!TP_OK(r)) memset(out, 0, sizeof(*out));
+    return r;
 }
 
 /* Walk the KVD block: a sequence of {u32 keyAndValueByteLength, key NUL value,
@@ -931,6 +965,10 @@ done:
 
 /* ---- KTX2 texture arrays (layerCount) ---- */
 
+/* As tp_ktx2_layout, but every level holds num_layers copies. Returns 0 if the
+ * layout overflows size_t -- the multiply by num_layers makes that reachable on
+ * a 32-bit target long before the 64-bit one, and an under-reported size here is
+ * what the payload memcpy would then run off the end of. */
 static size_t tp_ktx2_array_layout(const tp_blocks *layers, int num_layers,
                                    const tp_codec_desc *d, uint64_t *level_off,
                                    uint64_t *level_len) {
@@ -940,8 +978,14 @@ static size_t tp_ktx2_array_layout(const tp_blocks *layers, int num_layers,
     int ll;
     if (align < 4u) align = 4u;
     for (ll = layers[0].num_levels - 1; ll >= 0; --ll) {
-        size_t len = (size_t)num_layers * tp_ktx2_level_len(&layers[0], ll);
+        size_t one = tp_ktx2_level_len(&layers[0], ll);
+        size_t len;
+        if (one == TP_SIZE_OVF) return 0;
+        if (one != 0u && (size_t)num_layers > TP_SIZE_OVF / one) return 0;
+        len = (size_t)num_layers * one;
+        if (cursor > TP_SIZE_OVF - (align - 1u)) return 0;
         cursor = tp_align_up(cursor, align);
+        if (len > TP_SIZE_OVF - cursor) return 0;
         if (level_off) level_off[ll] = cursor;
         if (level_len) level_len[ll] = len;
         cursor += len;
@@ -953,6 +997,7 @@ size_t tp_ktx2_array_size(const tp_blocks *layers, int num_layers,
                           const tp_options *opt) {
     tp_codec_desc d;
     if (!layers || num_layers < 1 || !opt) return 0;
+    if (!tp_blocks_shape_ok(&layers[0], opt)) return 0;
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u) return 0;
     return tp_ktx2_array_layout(layers, num_layers, &d, NULL, NULL);
 }
@@ -967,18 +1012,18 @@ tp_result tp_write_ktx2_array(const tp_blocks *layers, int num_layers,
     size_t need, idx_base, dfd_off;
     int ll, layer, face, nlev, nface, li;
     if (!layers || num_layers < 1 || !opt || !out) return TP_ERROR_INVALID_ARGUMENT;
+    /* Checks layers[0]'s shape and its codec against opt's, before anything
+     * reads blk[0]. */
+    if (!tp_blocks_shape_ok(&layers[0], opt)) return TP_ERROR_UNSUPPORTED;
     nlev = layers[0].num_levels;
     nface = layers[0].num_faces;
-    if (nlev > 32) return TP_ERROR_UNSUPPORTED;
     /* The reader refuses layerCount past this, so writing more would only make a
      * file that cannot be loaded back. */
     if (num_layers > TP_KTX2_MAX_LAYERS) return TP_ERROR_UNSUPPORTED;
-    if (!tp_ktx2_dims_ok(layers[0].blk[0].width, layers[0].blk[0].height))
-        return TP_ERROR_UNSUPPORTED;
     for (li = 1; li < num_layers; ++li) {
         int k;
-        if (layers[li].num_levels != nlev || layers[li].num_faces != nface ||
-            layers[li].codec != layers[0].codec)
+        if (!layers[li].blk || layers[li].num_levels != nlev ||
+            layers[li].num_faces != nface || layers[li].codec != layers[0].codec)
             return TP_ERROR_INVALID_ARGUMENT;
         /* Every level's byte length is computed from layers[0] and multiplied by
          * num_layers, but the payload loop below copies each layer's own
@@ -994,6 +1039,7 @@ tp_result tp_write_ktx2_array(const tp_blocks *layers, int num_layers,
     if (!TP_OK(tp_codec_describe(opt->codec, opt, &d)) || d.vk_format == 0u)
         return TP_ERROR_UNSUPPORTED;
     need = tp_ktx2_array_layout(layers, num_layers, &d, level_off, level_len);
+    if (need == 0u) return TP_ERROR_INVALID_ARGUMENT; /* layout overflowed */
     if (out_size < need) return TP_ERROR_INVALID_ARGUMENT;
     memset(out, 0, need);
 

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -656,23 +656,20 @@ static void tp_write_uni_dfd(uint8_t *p) {
     tp_wr_u32(p + 40, 0xffffffffu);        /* sampleUpper */
 }
 
-/* Levels in the full pyramid for w0 x h0: floor(log2(max(w0, h0))) + 1. */
-static int tp_uni_max_levels(uint32_t w0, uint32_t h0) {
-    uint32_t m = w0 > h0 ? w0 : h0;
-    int n = 1;
-    while (m > 1u) { m >>= 1; ++n; }
-    return n;
-}
-
 /* Tightly-packed 4x4x16B payload of uni level `l`, sized off the base dimensions
  * the same way the reader derives them (width >> l, clamped to 1) rather than
- * off level_w[]/level_h[]. Returns 0 if the level is degenerate. */
-static size_t tp_uni_level_expected(uint32_t w0, uint32_t h0, int l) {
+ * off level_w[]/level_h[]. Computed in uint64 like the reader's
+ * tp_ktx2_level_expected: at the largest dimensions TP_KTX2_MAX_DIM admits the
+ * product is exactly 2^32, which a 32-bit size_t (the wasm build) would wrap to
+ * 0 -- and a 0 here would make the caller's size check accept a zero-length
+ * level. Such a level cannot fit in a 32-bit size_t anyway, so on those targets
+ * no uni_sizes[l] can match and the write is rejected, which is the point. */
+static uint64_t tp_uni_level_expected(uint32_t w0, uint32_t h0, int l) {
     uint32_t w = w0 >> l, h = h0 >> l;
     if (!w0 || !h0) return 0;
     if (!w) w = 1u;
     if (!h) h = 1u;
-    return (size_t)((w + 3u) / 4u) * (size_t)((h + 3u) / 4u) * 16u;
+    return (uint64_t)((w + 3u) / 4u) * (uint64_t)((h + 3u) / 4u) * 16u;
 }
 
 /* Total KTX2 byte size for `n` uni levels, filling loff[] with each level's
@@ -769,8 +766,7 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
     if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
         return TP_ERROR_INVALID_ARGUMENT;
     /* The reader refuses dimensions past TP_KTX2_MAX_DIM, so writing them would
-     * only produce a file we cannot read back (and would wrap the level-size
-     * math below on a 32-bit size_t). */
+     * only produce a file we cannot read back. */
     if (level_w[0] == 0u || level_h[0] == 0u ||
         level_w[0] > (uint32_t)TP_KTX2_MAX_DIM ||
         level_h[0] > (uint32_t)TP_KTX2_MAX_DIM)
@@ -778,7 +774,7 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
     /* levelCount past the pyramid the base dimensions imply is invalid KTX2:
      * the extra levels would all clamp to 1x1 and a loader that trusts
      * levelCount would bind mips that do not exist. */
-    if (num_levels > tp_uni_max_levels(level_w[0], level_h[0]))
+    if (num_levels > tp_level_count((int)level_w[0], (int)level_h[0], 0))
         return TP_ERROR_INVALID_ARGUMENT;
     for (l = 0; l < num_levels; ++l) comp[l] = NULL;
 
@@ -787,7 +783,8 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
      * produce a file our own reader rejects. Refuse it here instead. */
     for (l = 0; l < num_levels; ++l)
         if (!uni_levels[l] ||
-            uni_sizes[l] != tp_uni_level_expected(level_w[0], level_h[0], l))
+            (uint64_t)uni_sizes[l] !=
+                tp_uni_level_expected(level_w[0], level_h[0], l))
             return TP_ERROR_INVALID_ARGUMENT;
 
     /* Compress each level independently, so a reader can inflate one at a time. */

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -688,10 +688,11 @@ static void tp_write_uni_dfd(uint8_t *p, uint32_t flags) {
  * level. Such a level cannot fit in a 32-bit size_t anyway, so on those targets
  * no uni_sizes[l] can match and the write is rejected, which is the point. */
 static uint64_t tp_uni_level_expected(uint32_t w0, uint32_t h0, int l) {
-    uint32_t w = w0 >> l, h = h0 >> l;
+    uint32_t w, h;
     if (!w0 || !h0) return 0;
-    if (!w) w = 1u;
-    if (!h) h = 1u;
+    /* Same clamp-to-1 mip rule the rest of the pipeline uses. */
+    w = (uint32_t)tp_level_dim((int)w0, l);
+    h = (uint32_t)tp_level_dim((int)h0, l);
     return (uint64_t)((w + 3u) / 4u) * (uint64_t)((h + 3u) / 4u) * 16u;
 }
 
@@ -798,13 +799,22 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
     need = tp_ktx2_uni_layout(uni_sizes, num_levels, loff);
     if (need == 0u) return TP_ERROR_INVALID_ARGUMENT; /* layout overflowed */
     if (out_size < need) return TP_ERROR_INVALID_ARGUMENT;
-    /* Unlike the supercompressed layout, this one aligns each level to 16, so
-     * the padding between them has to be zeroed. */
-    memset(out, 0, need);
     tp_ktx2_uni_emit(out, base_w, base_h, num_levels, 0u, flags, loff, uni_sizes,
                      uni_sizes);
-    for (l = 0; l < num_levels; ++l)
-        memcpy(out + (size_t)loff[l], uni_levels[l], uni_sizes[l]);
+    /* Emit covered everything up to the level data, and the copies below cover
+     * the levels themselves. What is left is this layout's one gap: unlike the
+     * supercompressed one, it aligns each level to 16, and mipPadding must be
+     * zero. Zero just those gaps rather than the whole output, which for a large
+     * chain is an extra full pass over tens of MB. Levels run smallest-first, so
+     * walking l descending walks the file in address order. */
+    {
+        size_t cursor = 80u + (size_t)num_levels * 24u + 44u;
+        for (l = num_levels - 1; l >= 0; --l) {
+            memset(out + cursor, 0, (size_t)loff[l] - cursor);
+            memcpy(out + (size_t)loff[l], uni_levels[l], uni_sizes[l]);
+            cursor = (size_t)loff[l] + uni_sizes[l];
+        }
+    }
     if (written) *written = need;
     return TP_SUCCESS;
 }

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -109,14 +109,15 @@ tp_result tp_dds_write(const tp_blocks *b, const tp_options *opt, uint8_t *out,
 #define TP_KDF_MODEL_BC7 134u
 #define TP_KDF_MODEL_ETC2 161u
 #define TP_KDF_MODEL_ASTC 162u
-#define TP_KDF_MODEL_UASTC 166u
+#define TP_KDF_MODEL_UNSPECIFIED 0u
 #define TP_KDF_PRIMARIES_UNSPECIFIED 0u
 #define TP_KDF_PRIMARIES_BT709 1u
 #define TP_KDF_TRANSFER_LINEAR 1u
 #define TP_KDF_TRANSFER_SRGB 2u
-/* Sample channelType ids for the UASTC model (Khronos khr_df.h). */
-#define TP_KDF_CHANNEL_UASTC_RGB 0u
-#define TP_KDF_CHANNEL_UASTC_RGBA 3u
+/* Private uni channel ids. The private descriptor deliberately uses the
+ * UNSPECIFIED model rather than claiming Basis UASTC compatibility. */
+#define TP_KDF_CHANNEL_UNI_RGB 0u
+#define TP_KDF_CHANNEL_UNI_RGBA 3u
 
 static uint32_t tp_kdf_model(tp_codec codec) {
     switch (codec) {
@@ -426,7 +427,13 @@ static tp_result tp_ktx2_parse(const uint8_t *data, size_t size,
     }
 
     if (vk == 0u) {
-        out->is_uni = 1;              /* UASTC transcodable intermediate */
+        /* Basis UASTC also has vkFormat=UNDEFINED, but its wire representation
+         * is not texcomp uni. Only accept our private UNSPECIFIED-model DFD;
+         * treating KHR_DF_MODEL_UASTC as uni silently decodes corrupted pixels. */
+        if (dfd_len < 44u ||
+            data[(size_t)dfd_off + 12] != (uint8_t)TP_KDF_MODEL_UNSPECIFIED)
+            return TP_ERROR_UNSUPPORTED;
+        out->is_uni = 1;
         out->block_w = 4;
         out->block_h = 4;
         out->block_bytes = 16;
@@ -435,12 +442,11 @@ static tp_result tp_ktx2_parse(const uint8_t *data, size_t size,
          * pick an upload format and an alpha-capable transcode target. Parse the
          * two bytes we write; a DFD too short to hold them leaves the defaults
          * (linear, no alpha), which is what an absent DFD means anyway. */
-        if (dfd_len >= 44u &&
-            data[(size_t)dfd_off + 12] == (uint8_t)TP_KDF_MODEL_UASTC) {
+        {
             uint8_t transfer = data[(size_t)dfd_off + 14];
             uint8_t channels = data[(size_t)dfd_off + 31] & 0x0fu;
             out->srgb = (transfer == (uint8_t)TP_KDF_TRANSFER_SRGB);
-            out->has_alpha = (channels == (uint8_t)TP_KDF_CHANNEL_UASTC_RGBA);
+            out->has_alpha = (channels == (uint8_t)TP_KDF_CHANNEL_UNI_RGBA);
         }
     } else {
         tp_codec_desc d;
@@ -708,23 +714,20 @@ tp_result tp_ktx2_decode_slice_rgba8(const tp_ktx2_image *img, int level,
     }
 }
 
-/* ---- uni (UASTC) KTX2 writer: vkFormat=UNDEFINED, supercompression=0 ---- */
+/* ---- uni KTX2 writer: private carrier or standard ASTC 4x4 ---- */
 
-#define TP_UNI_FLAGS_ALL (TP_UNI_SRGB | TP_UNI_ALPHA)
+#define TP_UNI_FLAGS_ALL (TP_UNI_SRGB | TP_UNI_ALPHA | TP_UNI_ASTC_KTX2)
+#define TP_VK_ASTC_4X4_UNORM_BLOCK 157u
+#define TP_VK_ASTC_4X4_SRGB_BLOCK 158u
 
-/* KHR_DF UASTC descriptor (44 bytes), matching the uni-in-KTX2 convention.
- * `flags` is the caller's TP_UNI_SRGB / TP_UNI_ALPHA: neither is recoverable
- * from the block bytes, and both are what a DFD-honouring consumer keys off to
- * decide sRGB decode and whether to transcode into a format that has alpha. */
+/* Private uni descriptor (44 bytes). It deliberately uses colorModel =
+ * UNSPECIFIED: uni is not the Basis UASTC wire representation, and labelling it
+ * UASTC causes standards-compliant consumers to silently decode wrong pixels. */
 static void tp_write_uni_dfd(uint8_t *p, uint32_t flags) {
     memset(p, 0, 44);
     tp_wr_u32(p + 0, 44u);                 /* dfdTotalSize */
     tp_wr_u32(p + 8, 2u | (40u << 16));    /* version | descriptorBlockSize */
-    p[12] = (uint8_t)TP_KDF_MODEL_UASTC;
-    /* The glTF KHR_texture_basisu profile that `ktx validate` enforces admits
-     * exactly two colour pairings: BT709 primaries with sRGB transfer, or
-     * UNSPECIFIED primaries with linear. Non-colour uni data (normal, roughness)
-     * has no meaningful primaries, so pair linear with UNSPECIFIED. */
+    p[12] = (uint8_t)TP_KDF_MODEL_UNSPECIFIED;
     p[13] = (uint8_t)((flags & TP_UNI_SRGB) ? TP_KDF_PRIMARIES_BT709
                                             : TP_KDF_PRIMARIES_UNSPECIFIED);
     p[14] = (uint8_t)((flags & TP_UNI_SRGB) ? TP_KDF_TRANSFER_SRGB
@@ -735,8 +738,8 @@ static void tp_write_uni_dfd(uint8_t *p, uint32_t flags) {
      * and now requires the real value (0 merely warns as deprecated). */
     p[20] = 16u;                           /* bytesPlane0 */
     p[30] = 127u;                          /* sample bitLength (128 bits) */
-    p[31] = (uint8_t)((flags & TP_UNI_ALPHA) ? TP_KDF_CHANNEL_UASTC_RGBA
-                                             : TP_KDF_CHANNEL_UASTC_RGB);
+    p[31] = (uint8_t)((flags & TP_UNI_ALPHA) ? TP_KDF_CHANNEL_UNI_RGBA
+                                             : TP_KDF_CHANNEL_UNI_RGB);
     tp_wr_u32(p + 40, 0xffffffffu);        /* sampleUpper */
 }
 
@@ -815,9 +818,14 @@ static void tp_ktx2_uni_emit(uint8_t *buf, uint32_t base_w, uint32_t base_h,
                              const uint64_t *loff, const size_t *byte_len,
                              const size_t *uncompressed_len) {
     size_t dfd_off = 80u + (size_t)num_levels * 24u;
+    int astc_ktx2 = (flags & TP_UNI_ASTC_KTX2) != 0u;
     int l;
     memcpy(buf, tp_ktx2_id, 12);
-    tp_wr_u32(buf + 12, 0u);        /* vkFormat = UNDEFINED (uni) */
+    tp_wr_u32(buf + 12,
+              astc_ktx2 ? ((flags & TP_UNI_SRGB)
+                                ? TP_VK_ASTC_4X4_SRGB_BLOCK
+                                : TP_VK_ASTC_4X4_UNORM_BLOCK)
+                        : 0u);
     tp_wr_u32(buf + 16, 1u);        /* typeSize                   */
     tp_wr_u32(buf + 20, base_w);
     tp_wr_u32(buf + 24, base_h);
@@ -838,7 +846,17 @@ static void tp_ktx2_uni_emit(uint8_t *buf, uint32_t base_w, uint32_t base_h,
         tp_wr_u64(e + 8, (uint64_t)byte_len[l]);
         tp_wr_u64(e + 16, (uint64_t)uncompressed_len[l]);
     }
-    tp_write_uni_dfd(buf + dfd_off, flags);
+    if (astc_ktx2) {
+        tp_codec_desc d;
+        memset(&d, 0, sizeof(d));
+        d.block_w = 4;
+        d.block_h = 4;
+        d.block_bytes = 16;
+        tp_write_dfd(buf + dfd_off, &d, TP_CODEC_ASTC,
+                     (flags & TP_UNI_SRGB) != 0u);
+    } else {
+        tp_write_uni_dfd(buf + dfd_off, flags);
+    }
 }
 
 tp_result tp_ktx2_write_uni_ex(const uint8_t *const *uni_levels,

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -653,6 +653,17 @@ static void tp_write_uni_dfd(uint8_t *p) {
     tp_wr_u32(p + 40, 0xffffffffu);        /* sampleUpper */
 }
 
+/* Tightly-packed 4x4x16B payload of uni level `l`, sized off the base dimensions
+ * the same way the reader derives them (width >> l, clamped to 1) rather than
+ * off level_w[]/level_h[]. Returns 0 if the level is degenerate. */
+static size_t tp_uni_level_expected(uint32_t w0, uint32_t h0, int l) {
+    uint32_t w = w0 >> l, h = h0 >> l;
+    if (!w0 || !h0) return 0;
+    if (!w) w = 1u;
+    if (!h) h = 1u;
+    return (size_t)((w + 3u) / 4u) * (size_t)((h + 3u) / 4u) * 16u;
+}
+
 /* Total KTX2 byte size for `n` uni levels, filling loff[] with each level's
  * offset. Returns 0 if the layout overflows size_t (uni_sizes[] is caller data
  * on the public tp_ktx2_write_uni path, so it is not trusted to be sane). */
@@ -742,12 +753,21 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
         return TP_ERROR_INVALID_ARGUMENT;
     if (num_levels < 1 || num_levels > TP_KTX2_MAX_LEVELS)
         return TP_ERROR_INVALID_ARGUMENT;
+    if (level_w[0] == 0u || level_h[0] == 0u) return TP_ERROR_INVALID_ARGUMENT;
+    *out = NULL;
+    *out_size = 0;
     for (l = 0; l < num_levels; ++l) comp[l] = NULL;
+
+    /* A scheme-2 reader pins uncompressedByteLength to the exact block payload
+     * implied by the base dimensions, so a level whose size disagrees would
+     * produce a file our own reader rejects. Refuse it here instead. */
+    for (l = 0; l < num_levels; ++l)
+        if (uni_sizes[l] != tp_uni_level_expected(level_w[0], level_h[0], l))
+            return TP_ERROR_INVALID_ARGUMENT;
 
     /* Compress each level independently, so a reader can inflate one at a time. */
     for (l = 0; l < num_levels; ++l) {
         size_t bound;
-        if (uni_sizes[l] == 0) { r = TP_ERROR_INVALID_ARGUMENT; goto done; }
         bound = zbound(user, uni_sizes[l]);
         if (bound == 0) { r = TP_ERROR_UNSUPPORTED; goto done; }
         comp[l] = (uint8_t *)tp_alloc(a, bound);

--- a/tools/texpipe/src/texpipe_container.c
+++ b/tools/texpipe/src/texpipe_container.c
@@ -786,7 +786,9 @@ tp_result tp_ktx2_write_uni(const uint8_t *const *uni_levels,
                             const size_t *uni_sizes, uint32_t base_w,
                             uint32_t base_h, int num_levels, uint32_t flags,
                             uint8_t *out, size_t out_size, size_t *written) {
-    uint64_t loff[TP_KTX2_MAX_LEVELS];
+    /* Zeroed because tp_ktx2_uni_layout fills only [0, num_levels) and the
+     * compiler cannot see that across the call into tp_ktx2_uni_emit. */
+    uint64_t loff[TP_KTX2_MAX_LEVELS] = {0};
     size_t need;
     tp_result r;
     int l;
@@ -813,19 +815,23 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
                                  const size_t *uni_sizes, uint32_t base_w,
                                  uint32_t base_h, int num_levels, uint32_t flags,
                                  uint8_t **out, size_t *out_size) {
-    size_t clen[TP_KTX2_MAX_LEVELS];
-    uint64_t loff[TP_KTX2_MAX_LEVELS];
+    /* Zeroed for the same reason as in tp_ktx2_write_uni: the compiler cannot
+     * see that the loop below fills exactly [0, num_levels) before both arrays
+     * are handed to tp_ktx2_uni_emit. */
+    size_t clen[TP_KTX2_MAX_LEVELS] = {0};
+    uint64_t loff[TP_KTX2_MAX_LEVELS] = {0};
     const size_t smax = (size_t)-1;
     size_t head, cap, cursor;
-    uint8_t *buf = NULL;
+    uint8_t *buf = NULL, *fit = NULL;
     tp_result r;
     int l;
 
-    if (!zbound || !zenc || !out || !out_size) return TP_ERROR_INVALID_ARGUMENT;
-    /* Cleared before any other rejection: the contract is that a failed call
-     * leaves nothing for the caller to free. */
+    if (!out || !out_size) return TP_ERROR_INVALID_ARGUMENT;
+    /* Cleared before every other rejection, including the missing-callback one:
+     * the contract is that a failed call leaves nothing for the caller to free. */
     *out = NULL;
     *out_size = 0;
+    if (!zbound || !zenc) return TP_ERROR_INVALID_ARGUMENT;
     r = tp_uni_check(uni_levels, uni_sizes, base_w, base_h, num_levels, flags);
     if (!TP_OK(r)) return r;
 
@@ -833,12 +839,13 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
      * smallest-first. Supercompressed levels carry no mip padding -- KTX2 sets
      * required_alignment = 1 when supercompressionScheme != 0.
      *
-     * Size the buffer for the worst case (every level incompressible) and
-     * compress straight into it at a running cursor, rather than into per-level
-     * scratch that is then copied in. The compressed sizes are not known up
-     * front, so the buffer ends up larger than the file: *out_size is the real
-     * length. This keeps peak memory at one buffer instead of the scratch and
-     * the output at once, which is what the 32-bit wasm heap has room for. */
+     * The compressed sizes are not known up front, so compress into a worst-case
+     * buffer (every level incompressible) at a running cursor, then copy the
+     * result down into an exact-sized one. Compressing in place rather than into
+     * per-level scratch keeps this to two allocations instead of num_levels + 1,
+     * and the caller is handed a buffer the size of the actual file -- handing
+     * back the worst-case block would mean holding the whole uncompressed
+     * pyramid alive for a file that is typically a fraction of it. */
     head = 80u + (size_t)num_levels * 24u + 44u;
     cap = head;
     for (l = 0; l < num_levels; ++l) {
@@ -871,6 +878,14 @@ tp_result tp_ktx2_write_uni_zstd(const tir_allocator *a, tp_zstd_bound_fn zbound
      * from `head` to `cursor` -- so no memset is needed anywhere. */
     tp_ktx2_uni_emit(buf, base_w, base_h, num_levels, 2u, flags, loff, clen,
                      uni_sizes);
+
+    if (cursor < cap) {
+        fit = (uint8_t *)tp_alloc(a, cursor);
+        if (!fit) { r = TP_ERROR_OUT_OF_MEMORY; goto done; }
+        memcpy(fit, buf, cursor);
+        tp_dealloc(a, buf);
+        buf = fit;
+    }
     *out = buf;
     *out_size = cursor;
     return TP_SUCCESS;

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1594,6 +1594,72 @@ static size_t passthrough_zdec(void *user, uint8_t *dst, size_t dst_cap,
     return src_size;
 }
 
+/* Identity compressor pair, the write-side mirror of passthrough_zdec: exercises
+ * the tp_ktx2_write_uni_zstd layout / index / callback path without a real zstd
+ * (a stream it writes is then read back with passthrough_zdec). */
+static size_t passthrough_zbound(void *user, size_t src_size) {
+    (void)user;
+    return src_size;
+}
+static size_t passthrough_zenc(void *user, uint8_t *dst, size_t dst_cap,
+                               const uint8_t *src, size_t src_size) {
+    (void)user;
+    if (src_size > dst_cap) return 0;
+    memcpy(dst, src, src_size);
+    return src_size;
+}
+
+/* uni levels -> Zstd-supercompressed KTX2 -> read back -> decode. */
+static void test_ktx2_uni_zstd_write(void) {
+    const uint32_t W = 64, H = 64;
+    uint8_t *ref = make_gradient((int)W, (int)H);
+    uint8_t *uni = NULL, *ktx = NULL, *dec = NULL;
+    const uint8_t *levels[1];
+    size_t sizes[1], usz, ktx_n = 0;
+    uint32_t lw[1], lh[1];
+    tp_ktx2_image img;
+    const size_t npix = (size_t)W * H;
+
+    usz = tc_uni_compressed_size(W, H);
+    uni = (uint8_t *)malloc(usz);
+    CHECK(tc_uni_compress_rgba8(ref, W, H, (size_t)W * 4u, uni, usz) == TC_SUCCESS,
+          "uni compress");
+    levels[0] = uni; sizes[0] = usz; lw[0] = W; lh[0] = H;
+
+    CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
+                                       NULL, levels, sizes, lw, lh, 1, &ktx,
+                                       &ktx_n)),
+          "write uni zstd ktx2");
+    CHECK(ktx != NULL && ktx_n > 0, "zstd ktx2 produced");
+    CHECK(rd_u32(ktx + 44) == 2u, "supercompressionScheme = 2");
+    CHECK(rd_u32(ktx + 12) == 0u, "vkFormat = UNDEFINED (uni)");
+    CHECK(rd_u64(ktx + 96) == (uint64_t)usz, "uncompressedByteLength = uni size");
+
+    /* Plain tp_ktx2_read must refuse it; tp_ktx2_read_zstd must accept it. */
+    CHECK(tp_ktx2_read(ktx, ktx_n, &img) == TP_ERROR_UNSUPPORTED,
+          "scheme-2 needs a decompressor");
+    CHECK(TP_OK(tp_ktx2_read_zstd(ktx, ktx_n, NULL, passthrough_zdec, NULL, &img)),
+          "read back written zstd ktx2");
+    CHECK(img.is_uni && img.supercompression == 2u && img.width == W &&
+              img.num_levels == 1,
+          "round-trip header");
+
+    dec = (uint8_t *)malloc(npix * 4u);
+    CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, 0, dec, npix * 4u)),
+          "decode round-tripped level0");
+    {
+        double p = psnr_rgba(ref, dec, npix);
+        printf("    uni->zstd-KTX2->read->decode PSNR=%.2f dB\n", p);
+        CHECK(p >= 30.0, "zstd-ktx2 round-trip PSNR >= 30 dB");
+    }
+    tp_ktx2_image_free(NULL, &img);
+    tp_free(NULL, ktx);
+    free(dec);
+    free(uni);
+    free(ref);
+    printf("  ktx2 uni Zstd writer (write -> read -> decode): ok\n");
+}
+
 static void test_ktx2_zstd_scheme(void) {
     tir_image_view v;
     tp_options opt;
@@ -1713,6 +1779,7 @@ int main(void) {
     test_ktx2_kv();
     test_ktx2_bc6h_float();
     test_ktx2_zstd_scheme();
+    test_ktx2_uni_zstd_write();
     test_cube_seam_fixup();
     test_cube_split();
     test_cube_container();

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1654,6 +1654,22 @@ static void test_ktx2_uni_zstd_write(void) {
     }
     tp_ktx2_image_free(NULL, &img);
     tp_free(NULL, ktx);
+
+    /* A level size that disagrees with the dimensions would make a file the
+     * scheme-2 reader rejects (it pins uncompressedByteLength to the exact block
+     * payload), so the writer must refuse it -- and leave *out cleared. */
+    {
+        uint8_t *bad = (uint8_t *)0x1; /* must be overwritten with NULL */
+        size_t bad_n = 123u;
+        sizes[0] = usz - 16u;
+        CHECK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
+                                     NULL, levels, sizes, lw, lh, 1, &bad,
+                                     &bad_n) == TP_ERROR_INVALID_ARGUMENT,
+              "writer refuses a level size that mismatches the dimensions");
+        CHECK(bad == NULL && bad_n == 0u, "outputs cleared on failure");
+        sizes[0] = usz;
+    }
+
     free(dec);
     free(uni);
     free(ref);

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -9,6 +9,10 @@
  */
 #include "texpipe.h"
 
+/* tp_ktx2_size / tp_ktx2_write are internal (the public single-image entry point
+ * is tp_process); the argument-rejection tests below exercise them directly. */
+#include "../src/texpipe_internal.h"
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1761,6 +1761,76 @@ static void test_ktx2_uni_zstd_write(void) {
               "reject an unknown uni flag bit");
     }
 
+    /* A real mip chain. The single-level case above exercises none of the actual
+     * new logic: the levels are packed smallest-first at a running cursor, and
+     * every level's offset/byteLength/uncompressedByteLength lands in the index.
+     * With one level, a reversed or off-by-one packing loop still round-trips. */
+    {
+        const int NL = 3; /* 64x64, 32x32, 16x16 */
+        uint8_t *mref[3], *muni[3];
+        const uint8_t *mlev[3];
+        size_t msz[3];
+        uint8_t *k2 = NULL;
+        size_t k2n = 0;
+        int l;
+        for (l = 0; l < NL; ++l) {
+            uint32_t w = W >> l, h = H >> l;
+            mref[l] = make_gradient((int)w, (int)h);
+            msz[l] = tc_uni_compressed_size(w, h);
+            muni[l] = (uint8_t *)malloc(msz[l]);
+            CHECK(tc_uni_compress_rgba8(mref[l], w, h, (size_t)w * 4u, muni[l],
+                                        msz[l]) == TC_SUCCESS,
+                  "uni compress mip level");
+            mlev[l] = muni[l];
+        }
+        CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
+                                           passthrough_zenc, NULL, mlev, msz, W,
+                                           H, NL, TP_UNI_SRGB, &k2, &k2n)),
+              "write 3-level uni zstd ktx2");
+
+        /* The index must describe three levels that are in-bounds, non-empty and
+         * non-overlapping -- a reversed packing loop would alias them. */
+        {
+            uint64_t prev_end = 0;
+            for (l = NL - 1; l >= 0; --l) { /* smallest first, i.e. ascending offset */
+                uint64_t off = rd_u64(k2 + 80 + (size_t)l * 24 + 0);
+                uint64_t blen = rd_u64(k2 + 80 + (size_t)l * 24 + 8);
+                uint64_t ulen = rd_u64(k2 + 80 + (size_t)l * 24 + 16);
+                CHECK(off >= prev_end, "level does not overlap the previous one");
+                CHECK(blen > 0 && off + blen <= (uint64_t)k2n,
+                      "level payload lies inside the file");
+                CHECK(ulen == (uint64_t)msz[l], "uncompressedByteLength = uni size");
+                prev_end = off + blen;
+            }
+            CHECK(prev_end == (uint64_t)k2n, "levels exactly fill the file");
+        }
+
+        CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
+                                      &img)),
+              "read back 3-level zstd ktx2");
+        CHECK(img.num_levels == NL && img.width == W && img.height == H,
+              "3-level round-trip header");
+        /* Decode every level, not just level 0: a mixed-up index would surface
+         * as the wrong mip decoding cleanly at the wrong size. */
+        for (l = 0; l < NL; ++l) {
+            uint32_t w = W >> l, h = H >> l;
+            size_t n = (size_t)w * h;
+            uint8_t *d = (uint8_t *)malloc(n * 4u);
+            double p;
+            CHECK(img.levels[l].width == w && img.levels[l].height == h,
+                  "level dimensions");
+            CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, l, d, n * 4u)),
+                  "decode mip level");
+            p = psnr_rgba(mref[l], d, n);
+            printf("    uni->zstd-KTX2 mip %d (%ux%u) PSNR=%.2f dB\n", l, w, h, p);
+            CHECK(p >= 30.0, "mip level round-trips to the right image");
+            free(d);
+        }
+        tp_ktx2_image_free(NULL, &img);
+        tp_free(NULL, k2);
+        for (l = 0; l < NL; ++l) { free(mref[l]); free(muni[l]); }
+    }
+
     free(dec);
     free(uni);
     free(ref);

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1614,17 +1614,23 @@ static void test_ktx2_uni_zstd_write(void) {
     const uint32_t W = 64, H = 64;
     uint8_t *ref = make_gradient((int)W, (int)H);
     uint8_t *uni = NULL, *ktx = NULL, *dec = NULL;
-    const uint8_t *levels[1];
-    size_t sizes[1], usz, ktx_n = 0;
-    uint32_t lw[1], lh[1];
+    /* Sized for the largest num_levels the negative cases below pass in, so a
+     * writer that validated in the wrong order would read past the array rather
+     * than quietly staying in bounds. */
+    const uint8_t *levels[TP_KTX2_MAX_LEVELS];
+    size_t sizes[TP_KTX2_MAX_LEVELS], usz, ktx_n = 0;
+    uint32_t lw[TP_KTX2_MAX_LEVELS], lh[TP_KTX2_MAX_LEVELS];
     tp_ktx2_image img;
     const size_t npix = (size_t)W * H;
+    int i;
 
     usz = tc_uni_compressed_size(W, H);
     uni = (uint8_t *)malloc(usz);
     CHECK(tc_uni_compress_rgba8(ref, W, H, (size_t)W * 4u, uni, usz) == TC_SUCCESS,
           "uni compress");
-    levels[0] = uni; sizes[0] = usz; lw[0] = W; lh[0] = H;
+    for (i = 0; i < TP_KTX2_MAX_LEVELS; ++i) {
+        levels[i] = uni; sizes[i] = usz; lw[i] = W; lh[i] = H;
+    }
 
     CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
                                        NULL, levels, sizes, lw, lh, 1, &ktx,
@@ -1666,11 +1672,17 @@ static void test_ktx2_uni_zstd_write(void) {
             {"dimension over TP_KTX2_MAX_DIM", 0, 131072, 64, 1},
             /* more levels than the 64x64 pyramid has (7) */
             {"levelCount past the mip pyramid", 0, 64, 64, 9},
+            /* The MAX_DIM corner: the level payload is exactly 2^32 B, which the
+             * expected-size math must not wrap to 0 (it would then match this
+             * zero-length level and emit a file the reader rejects). Rejected on
+             * every target -- 2^32 does not fit a 32-bit size_t at all. */
+            {"zero-length level at the 65536x65536 corner", 0, 65536, 65536, 1},
         };
         size_t i;
         bad_in[0].sz = usz - 16u;
         bad_in[1].sz = usz;
         bad_in[2].sz = usz;
+        bad_in[3].sz = 0;
         for (i = 0; i < sizeof(bad_in) / sizeof(bad_in[0]); ++i) {
             uint8_t *bad = (uint8_t *)0x1; /* must be overwritten with NULL */
             size_t bad_n = 123u;

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -821,6 +821,42 @@ static void test_array_ktx2(void) {
         tp_mip_chain_free(NULL, &chain2);
         free(img2);
     }
+
+    /* A zeroed tp_blocks is what a tp_compress_chain that failed leaves behind.
+     * num_levels == 0 with a NULL blk must be an error, not a NULL dereference
+     * of blk[0] inside the writers' own dimension check. */
+    {
+        tp_blocks empty;
+        uint8_t sink[256];
+        size_t w2 = 0;
+        memset(&empty, 0, sizeof(empty));
+        CHECK(tp_ktx2_size(&empty, &opt) == 0, "ktx2_size rejects a zeroed blocks");
+        CHECK(tp_ktx2_write(&empty, &opt, sink, sizeof(sink), &w2) != TP_SUCCESS,
+              "ktx2_write rejects a zeroed blocks");
+        CHECK(tp_ktx2_array_size(&empty, 1, &opt) == 0,
+              "array_size rejects a zeroed blocks");
+        CHECK(tp_write_ktx2_array(&empty, 1, &opt, sink, sizeof(sink), &w2) !=
+                  TP_SUCCESS,
+              "array write rejects a zeroed blocks");
+    }
+
+    /* The payload bytes come from `b` but the vkFormat and DFD come from opt: if
+     * they disagree the file describes BC1 over BC7 blocks and every reader
+     * decodes garbage. */
+    {
+        tp_options wrong;
+        uint8_t sink[256];
+        size_t w2 = 0;
+        tp_options_init(&wrong, TP_CONTENT_COLOR, TP_CODEC_BC1);
+        CHECK(b.codec == TP_CODEC_BC7, "blocks were encoded as BC7");
+        CHECK(tp_ktx2_size(&b, &wrong) == 0,
+              "ktx2_size rejects a codec that disagrees with the blocks");
+        CHECK(tp_ktx2_write(&b, &wrong, sink, sizeof(sink), &w2) != TP_SUCCESS,
+              "ktx2_write rejects a codec that disagrees with the blocks");
+        CHECK(tp_write_ktx2_array(layers, 3, &wrong, sink, sizeof(sink), &w2) !=
+                  TP_SUCCESS,
+              "array write rejects a codec that disagrees with the blocks");
+    }
     printf("  array ktx2 (layerCount=3): ok\n");
     free(buf);
     tp_blocks_free(NULL, &b);
@@ -1614,27 +1650,43 @@ static void test_ktx2_read_roundtrip(void) {
     {
         const uint8_t *ulev[2];
         size_t usz[2];
-        uint8_t dummy[16];
+        uint8_t block[16];
+        /* Big enough for the real file (80 + 2*24 + 44, 16-aligned, + two 16 B
+         * levels = 208). Passing a short buffer here would make every rejection
+         * below fire on `out_size < need` instead of the rule under test, so the
+         * asserts would pass even with the validation deleted. */
+        uint8_t obuf[256];
         size_t wrote = 0;
-        ulev[0] = dummy; ulev[1] = dummy;
+        ulev[0] = block; ulev[1] = block;
         usz[0] = (size_t)-1 - 64u; usz[1] = 1024u; /* cursor + sizes[0] wraps */
         CHECK(tp_ktx2_uni_size(usz, 2) == 0, "uni layout overflow -> size 0");
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, dummy, sizeof(dummy),
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "reject uni write with overflowing level sizes");
+
+        /* The control: with a correct 4x4 two-level chain and this same buffer
+         * the write succeeds. Every rejection below therefore comes from the
+         * rule it names, not from the output buffer being too small. */
+        usz[0] = 16u; usz[1] = 16u; /* 4x4 and 2x2 are one block each */
+        CHECK(TP_OK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
+                                      &wrote)),
+              "control: a valid 4x4 2-level uni write succeeds into this buffer");
+        CHECK(wrote == 208u, "control: the file is 208 bytes");
 
         /* The scheme-0 writer now enforces the same rules as the Zstd one: each
          * of these emits a file tp_ktx2_read would refuse, so the write must
          * fail rather than hand back an unloadable asset. */
-        usz[0] = 16u; usz[1] = 16u; /* 4x4 and 2x2 are one block each */
-        CHECK(tp_ktx2_write_uni(ulev, usz, 131072, 4, 2, 0u, dummy, sizeof(dummy),
+        CHECK(tp_ktx2_write_uni(ulev, usz, 131072, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects a dimension over TP_KTX2_MAX_DIM");
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0x4u, dummy, sizeof(dummy),
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0x4u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects an unknown flag bit");
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 8, 0u, obuf, sizeof(obuf),
+                                &wrote) == TP_ERROR_INVALID_ARGUMENT,
+              "write_uni rejects levelCount past the 4x4 pyramid");
         usz[1] = 32u; /* level 1 of a 4x4 base is 2x2 = one block = 16 B */
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, dummy, sizeof(dummy),
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects a level size that mismatches the dimensions");
     }
@@ -1658,9 +1710,14 @@ static size_t passthrough_zdec(void *user, uint8_t *dst, size_t dst_cap,
 /* Identity compressor pair, the write-side mirror of passthrough_zdec: exercises
  * the tp_ktx2_write_uni_zstd layout / index / callback path without a real zstd
  * (a stream it writes is then read back with passthrough_zdec). */
+/* Deliberately over-reports, the way ZSTD_compressBound does. An identity zenc
+ * then produces clen < bound, so the writer's buffer ends up bigger than the
+ * file and its shrink-copy path runs -- the path every real zstd caller takes.
+ * With bound == src_size the compressed data would exactly fill the worst-case
+ * buffer and that branch would never execute in CI. */
 static size_t passthrough_zbound(void *user, size_t src_size) {
     (void)user;
-    return src_size;
+    return src_size + 64u;
 }
 static size_t passthrough_zenc(void *user, uint8_t *dst, size_t dst_cap,
                                const uint8_t *src, size_t src_size) {

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1853,15 +1853,26 @@ static void test_ktx2_uni_zstd_write(void) {
             CHECK(TP_OK(tp_ktx2_write_uni(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
                                           raw_n, NULL)),
                   "write 3-level uni ktx2 (scheme 0)");
+            memset(raw, 0xAB, raw_n); /* poison: only what the writer writes may survive */
+            CHECK(TP_OK(tp_ktx2_write_uni(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
+                                          raw_n, NULL)),
+                  "rewrite 3-level uni ktx2 over poison");
+            prev_end = 80u + (uint64_t)NL * 24u + 44u; /* end of the DFD */
             for (l = NL - 1; l >= 0; --l) { /* smallest first = ascending offset */
                 uint64_t off = rd_u64(raw + 80 + (size_t)l * 24 + 0);
                 uint64_t blen = rd_u64(raw + 80 + (size_t)l * 24 + 8);
+                uint64_t p;
                 CHECK(off % 16u == 0u, "scheme-0 level is 16-byte aligned");
                 CHECK(off >= prev_end, "scheme-0 level does not overlap the previous");
                 CHECK(blen == (uint64_t)msz[l], "scheme-0 byteLength = uni size");
                 CHECK(off + blen <= (uint64_t)raw_n, "scheme-0 level is in-bounds");
+                /* KTX2 requires mipPadding to be zero; the writer only zeroes the
+                 * gaps now, so a missed gap would leave the poison behind. */
+                for (p = prev_end; p < off; ++p)
+                    CHECK(raw[p] == 0u, "scheme-0 mipPadding is zeroed");
                 prev_end = off + blen;
             }
+            CHECK(prev_end == (uint64_t)raw_n, "scheme-0 levels reach the end of the file");
             CHECK(TP_OK(tp_ktx2_read(raw, raw_n, &img)), "read 3-level uni ktx2");
             CHECK(img.num_levels == NL, "scheme-0 3-level header");
             for (l = 0; l < NL; ++l) {

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1759,6 +1759,17 @@ static void test_ktx2_uni_zstd_write(void) {
                                      NULL, levels, sizes, W, H, 1, 0x8u, &k2,
                                      &k2n) == TP_ERROR_INVALID_ARGUMENT,
               "reject an unknown uni flag bit");
+
+        /* A host built without zstd passes no callbacks. That rejection must
+         * clear the outputs too -- it is the one path that returns before the
+         * argument checks, and the header promises the clear unconditionally. */
+        k2 = (uint8_t *)0x1;
+        k2n = 123u;
+        CHECK(tp_ktx2_write_uni_zstd(NULL, NULL, NULL, NULL, levels, sizes, W, H,
+                                     1, 0u, &k2,
+                                     &k2n) == TP_ERROR_INVALID_ARGUMENT,
+              "reject a missing zstd callback pair");
+        CHECK(k2 == NULL && k2n == 0u, "outputs cleared when callbacks are NULL");
     }
 
     /* A real mip chain. The single-level case above exercises none of the actual
@@ -1828,6 +1839,44 @@ static void test_ktx2_uni_zstd_write(void) {
         }
         tp_ktx2_image_free(NULL, &img);
         tp_free(NULL, k2);
+
+        /* The same chain through the scheme-0 writer, which shares the layout
+         * and emit helpers but keeps its own 16-byte level alignment. Without
+         * this, dropping the tp_align_up or reversing the layout loop would
+         * leave the suite green while every multi-mip uni KTX2 came out with
+         * misaligned or aliased levels. */
+        {
+            size_t raw_n = tp_ktx2_uni_size(msz, NL);
+            uint8_t *raw = (uint8_t *)malloc(raw_n);
+            uint64_t prev_end = 0;
+            CHECK(raw_n > 0, "uni size for a 3-level chain");
+            CHECK(TP_OK(tp_ktx2_write_uni(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
+                                          raw_n, NULL)),
+                  "write 3-level uni ktx2 (scheme 0)");
+            for (l = NL - 1; l >= 0; --l) { /* smallest first = ascending offset */
+                uint64_t off = rd_u64(raw + 80 + (size_t)l * 24 + 0);
+                uint64_t blen = rd_u64(raw + 80 + (size_t)l * 24 + 8);
+                CHECK(off % 16u == 0u, "scheme-0 level is 16-byte aligned");
+                CHECK(off >= prev_end, "scheme-0 level does not overlap the previous");
+                CHECK(blen == (uint64_t)msz[l], "scheme-0 byteLength = uni size");
+                CHECK(off + blen <= (uint64_t)raw_n, "scheme-0 level is in-bounds");
+                prev_end = off + blen;
+            }
+            CHECK(TP_OK(tp_ktx2_read(raw, raw_n, &img)), "read 3-level uni ktx2");
+            CHECK(img.num_levels == NL, "scheme-0 3-level header");
+            for (l = 0; l < NL; ++l) {
+                uint32_t w = W >> l, h = H >> l;
+                size_t n = (size_t)w * h;
+                uint8_t *d = (uint8_t *)malloc(n * 4u);
+                CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, l, d, n * 4u)),
+                      "decode scheme-0 mip level");
+                CHECK(psnr_rgba(mref[l], d, n) >= 30.0,
+                      "scheme-0 mip round-trips to the right image");
+                free(d);
+            }
+            tp_ktx2_image_free(NULL, &img);
+            free(raw);
+        }
         for (l = 0; l < NL; ++l) { free(mref[l]); free(muni[l]); }
     }
 

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1655,19 +1655,49 @@ static void test_ktx2_uni_zstd_write(void) {
     tp_ktx2_image_free(NULL, &img);
     tp_free(NULL, ktx);
 
-    /* A level size that disagrees with the dimensions would make a file the
-     * scheme-2 reader rejects (it pins uncompressedByteLength to the exact block
-     * payload), so the writer must refuse it -- and leave *out cleared. */
+    /* Inputs the writer must refuse, because each one yields a file that either
+     * its own reader or `ktx validate` rejects. Every rejection must also leave
+     * *out / *out_size cleared: callers free unconditionally. */
     {
-        uint8_t *bad = (uint8_t *)0x1; /* must be overwritten with NULL */
-        size_t bad_n = 123u;
-        sizes[0] = usz - 16u;
-        CHECK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
-                                     NULL, levels, sizes, lw, lh, 1, &bad,
-                                     &bad_n) == TP_ERROR_INVALID_ARGUMENT,
-              "writer refuses a level size that mismatches the dimensions");
-        CHECK(bad == NULL && bad_n == 0u, "outputs cleared on failure");
-        sizes[0] = usz;
+        struct { const char *what; size_t sz; uint32_t w, h; int n; } bad_in[] = {
+            /* size disagrees with the dims (reader pins uncompressedByteLength) */
+            {"level size mismatches the dimensions", 0, 64, 64, 1},
+            /* dims past TP_KTX2_MAX_DIM: the reader refuses to load them back */
+            {"dimension over TP_KTX2_MAX_DIM", 0, 131072, 64, 1},
+            /* more levels than the 64x64 pyramid has (7) */
+            {"levelCount past the mip pyramid", 0, 64, 64, 9},
+        };
+        size_t i;
+        bad_in[0].sz = usz - 16u;
+        bad_in[1].sz = usz;
+        bad_in[2].sz = usz;
+        for (i = 0; i < sizeof(bad_in) / sizeof(bad_in[0]); ++i) {
+            uint8_t *bad = (uint8_t *)0x1; /* must be overwritten with NULL */
+            size_t bad_n = 123u;
+            sizes[0] = bad_in[i].sz; lw[0] = bad_in[i].w; lh[0] = bad_in[i].h;
+            CHECK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
+                                         passthrough_zenc, NULL, levels, sizes,
+                                         lw, lh, bad_in[i].n, &bad,
+                                         &bad_n) == TP_ERROR_INVALID_ARGUMENT,
+                  bad_in[i].what);
+            CHECK(bad == NULL && bad_n == 0u, "outputs cleared on failure");
+        }
+        sizes[0] = usz; lw[0] = W; lh[0] = H;
+    }
+
+    /* KTX2 >= 2.0.4: a supercompressed file keeps the real pre-deflation
+     * bytesPlane0 (the old "must be 0" rule is retired), so the DFD the writer
+     * emits must still say 16 even under scheme 2. */
+    {
+        uint8_t *k2 = NULL;
+        size_t k2n = 0, dfd_off;
+        CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
+                                           passthrough_zenc, NULL, levels, sizes,
+                                           lw, lh, 1, &k2, &k2n)),
+              "rewrite for DFD check");
+        dfd_off = rd_u32(k2 + 48);
+        CHECK(k2[dfd_off + 20] == 16u, "DFD bytesPlane0 = 16 under scheme 2");
+        tp_free(NULL, k2);
     }
 
     free(dec);

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -99,13 +99,18 @@ static double psnr_rg(const uint8_t *a, const uint8_t *b, size_t npix) {
 /* Smooth RGBA gradient (opaque). */
 static uint8_t *make_gradient(int w, int h) {
     uint8_t *img = (uint8_t *)malloc((size_t)w * h * 4);
+    /* A 1-wide or 1-tall image (the tail of any mip chain) has no span to
+     * divide by; hold that axis at 0 rather than dividing by zero. */
+    int dw = w > 1 ? w - 1 : 1;
+    int dh = h > 1 ? h - 1 : 1;
+    int dd = (w + h - 2) > 0 ? w + h - 2 : 1;
     int x, y;
     for (y = 0; y < h; ++y)
         for (x = 0; x < w; ++x) {
             uint8_t *p = img + (y * w + x) * 4;
-            p[0] = (uint8_t)(x * 255 / (w - 1));
-            p[1] = (uint8_t)(y * 255 / (h - 1));
-            p[2] = (uint8_t)((x + y) * 255 / (w + h - 2));
+            p[0] = (uint8_t)(x * 255 / dw);
+            p[1] = (uint8_t)(y * 255 / dh);
+            p[2] = (uint8_t)((x + y) * 255 / dd);
             p[3] = 255;
         }
     return img;
@@ -780,6 +785,41 @@ static void test_array_ktx2(void) {
                   TP_ERROR_INVALID_ARGUMENT, "array: reject out-of-range face");
         free(d0);
         free(dn);
+    }
+    /* Layers of differing dimensions: the file is sized from layers[0] but the
+     * payload loop copies each layer's own blocks, so a bigger layer used to
+     * memcpy straight off the end of `buf`. It must be refused instead. The
+     * existing cases above cannot catch this -- they reuse one tp_blocks for
+     * every layer, so the sizes trivially agree. */
+    {
+        tir_image_view v2;
+        tp_mip_chain chain2;
+        tp_blocks b2, mixed[2];
+        uint8_t *img2 = make_gradient(65, 65);
+        uint8_t *small = NULL;
+        size_t need2;
+        /* 65x65 has the same 7-level pyramid as 64x64 (so the existing
+         * num_levels/num_faces/codec equality check passes) but 17x17 blocks
+         * instead of 16x16 -- 4624 bytes at level 0 against 4096. */
+        view_u8(&v2, img2, 65, 65);
+        memset(&chain2, 0, sizeof(chain2));
+        memset(&b2, 0, sizeof(b2));
+        CHECK(TP_OK(tp_build_mips(NULL, &v2, 1, &opt, &chain2)), "array: build 65");
+        CHECK(TP_OK(tp_compress_chain(NULL, &chain2, &opt, &b2)), "array: compress 65");
+        CHECK(b2.num_levels == b.num_levels,
+              "array: 65x65 and 64x64 have the same level count");
+        CHECK(b2.blk[0].size > b.blk[0].size, "array: 65x65 level 0 is bigger");
+        mixed[0] = b;   /* 64x64, which the file gets sized from */
+        mixed[1] = b2;  /* 65x65, whose blocks are larger */
+        need2 = tp_ktx2_array_size(mixed, 2, &opt);
+        small = (uint8_t *)malloc(need2);
+        CHECK(tp_write_ktx2_array(mixed, 2, &opt, small, need2, &wrote) !=
+                  TP_SUCCESS,
+              "array: reject layers whose dimensions disagree");
+        free(small);
+        tp_blocks_free(NULL, &b2);
+        tp_mip_chain_free(NULL, &chain2);
+        free(img2);
     }
     printf("  array ktx2 (layerCount=3): ok\n");
     free(buf);
@@ -1740,6 +1780,14 @@ static void test_ktx2_uni_zstd_write(void) {
         CHECK(k2[dfd + 13] == 1u, "DFD primaries = BT709 (sRGB)");
         CHECK(k2[dfd + 14] == 2u, "DFD transfer = sRGB");
         CHECK(k2[dfd + 31] == 3u, "DFD channelType = UASTC_RGBA");
+        /* The flags must survive the round trip: a uni file has no vkFormat, so
+         * if the reader does not parse the DFD the caller cannot tell sRGB from
+         * linear or RGBA from RGB, and the flags buy nothing. */
+        CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
+                                      &img)),
+              "read back srgb+alpha uni");
+        CHECK(img.srgb == 1 && img.has_alpha == 1, "reader recovers srgb + alpha");
+        tp_ktx2_image_free(NULL, &img);
         tp_free(NULL, k2);
 
         /* Linear + no alpha: the glTF profile pairs linear with UNSPECIFIED
@@ -1752,6 +1800,12 @@ static void test_ktx2_uni_zstd_write(void) {
         CHECK(k2[dfd + 13] == 0u, "DFD primaries = UNSPECIFIED (linear)");
         CHECK(k2[dfd + 14] == 1u, "DFD transfer = linear");
         CHECK(k2[dfd + 31] == 0u, "DFD channelType = UASTC_RGB");
+        CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
+                                      &img)),
+              "read back linear uni");
+        CHECK(img.srgb == 0 && img.has_alpha == 0,
+              "reader recovers linear + no alpha");
+        tp_ktx2_image_free(NULL, &img);
         tp_free(NULL, k2);
 
         /* An unknown flag bit is a caller bug, not something to silently drop. */
@@ -1889,6 +1943,67 @@ static void test_ktx2_uni_zstd_write(void) {
             free(raw);
         }
         for (l = 0; l < NL; ++l) { free(mref[l]); free(muni[l]); }
+    }
+
+    /* Non-power-of-two, where the block grid does not divide the dimensions and
+     * the mip chain stops halving cleanly (65 -> 32 -> 16). Every level size the
+     * writer demands is computed from the base dims, so an NPOT rounding
+     * disagreement between writer and reader shows up here and nowhere else. */
+    {
+        const uint32_t NW = 65, NH = 33;
+        const int NNL = 7; /* tp_level_count(65, 33) */
+        uint8_t *nref[7], *nuni[7];
+        const uint8_t *nlev[7];
+        size_t nsz[7];
+        uint8_t *k2 = NULL;
+        size_t k2n = 0;
+        int l;
+        for (l = 0; l < NNL; ++l) {
+            uint32_t w = NW >> l, h = NH >> l;
+            if (!w) w = 1u;
+            if (!h) h = 1u;
+            nref[l] = make_gradient((int)w, (int)h);
+            nsz[l] = tc_uni_compressed_size(w, h);
+            nuni[l] = (uint8_t *)malloc(nsz[l]);
+            CHECK(tc_uni_compress_rgba8(nref[l], w, h, (size_t)w * 4u, nuni[l],
+                                        nsz[l]) == TC_SUCCESS,
+                  "npot uni compress");
+            nlev[l] = nuni[l];
+        }
+        CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
+                                           passthrough_zenc, NULL, nlev, nsz, NW,
+                                           NH, NNL, TP_UNI_SRGB, &k2, &k2n)),
+              "write NPOT (65x33) uni zstd ktx2");
+        CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
+                                      &img)),
+              "read back NPOT uni zstd ktx2");
+        CHECK(img.width == NW && img.height == NH && img.num_levels == NNL,
+              "NPOT header round-trips");
+        for (l = 0; l < NNL; ++l) {
+            uint32_t w = NW >> l, h = NH >> l;
+            size_t n;
+            uint8_t *d;
+            if (!w) w = 1u;
+            if (!h) h = 1u;
+            n = (size_t)w * h;
+            d = (uint8_t *)malloc(n * 4u);
+            CHECK(img.levels[l].width == w && img.levels[l].height == h,
+                  "NPOT level dimensions");
+            CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, l, d, n * 4u)),
+                  "decode NPOT mip level");
+            /* What is under test is the container, not UASTC's rate-distortion:
+             * the tiny levels are one or two blocks of a steep gradient, where
+             * 25 dB is simply what the codec gives (a mixed-up level would come
+             * back at single-digit dB, not 25). Hold the big levels to the usual
+             * bar and only require the small ones to be recognizably the right
+             * image. */
+            CHECK(psnr_rgba(nref[l], d, n) >= (n >= 256 ? 30.0 : 20.0),
+                  "NPOT mip round-trips to the right image");
+            free(d);
+        }
+        tp_ktx2_image_free(NULL, &img);
+        tp_free(NULL, k2);
+        for (l = 0; l < NNL; ++l) { free(nref[l]); free(nuni[l]); }
     }
 
     free(dec);

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1557,7 +1557,7 @@ static void test_ktx2_read_roundtrip(void) {
         levels[0] = uni; sizes[0] = usz;
         ktx_size = tp_ktx2_uni_size(sizes, 1);
         ubuf = (uint8_t *)malloc(ktx_size);
-        CHECK(TP_OK(tp_ktx2_write_uni(levels, sizes, 64, 64, 1, TP_UNI_SRGB,
+        CHECK(TP_OK(tp_ktx2_write_uni_ex(levels, sizes, 64, 64, 1, TP_UNI_SRGB,
                                       ubuf, ktx_size, NULL)),
               "write uni ktx2");
         /* The DFD must carry the flags the caller asked for: sRGB transfer (2),
@@ -1660,7 +1660,7 @@ static void test_ktx2_read_roundtrip(void) {
         ulev[0] = block; ulev[1] = block;
         usz[0] = (size_t)-1 - 64u; usz[1] = 1024u; /* cursor + sizes[0] wraps */
         CHECK(tp_ktx2_uni_size(usz, 2) == 0, "uni layout overflow -> size 0");
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "reject uni write with overflowing level sizes");
 
@@ -1668,7 +1668,7 @@ static void test_ktx2_read_roundtrip(void) {
          * the write succeeds. Every rejection below therefore comes from the
          * rule it names, not from the output buffer being too small. */
         usz[0] = 16u; usz[1] = 16u; /* 4x4 and 2x2 are one block each */
-        CHECK(TP_OK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
+        CHECK(TP_OK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
                                       &wrote)),
               "control: a valid 4x4 2-level uni write succeeds into this buffer");
         CHECK(wrote == 208u, "control: the file is 208 bytes");
@@ -1676,19 +1676,46 @@ static void test_ktx2_read_roundtrip(void) {
         /* The scheme-0 writer now enforces the same rules as the Zstd one: each
          * of these emits a file tp_ktx2_read would refuse, so the write must
          * fail rather than hand back an unloadable asset. */
-        CHECK(tp_ktx2_write_uni(ulev, usz, 131072, 4, 2, 0u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 131072, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects a dimension over TP_KTX2_MAX_DIM");
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0x4u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0x4u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects an unknown flag bit");
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 8, 0u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 8, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects levelCount past the 4x4 pyramid");
         usz[1] = 32u; /* level 1 of a 4x4 base is 2x2 = one block = 16 B */
-        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects a level size that mismatches the dimensions");
+
+        /* The pre-flags form still compiles and still behaves: same call through
+         * the old signature must produce the byte-identical file that
+         * tp_ktx2_write_uni_ex(..., flags = 0) does. This is the compatibility
+         * guarantee for callers already on the release branch. */
+        {
+            uint32_t lw2[2], lh2[2];
+            uint8_t legacy[256];
+            size_t wrote_legacy = 0;
+            usz[0] = 16u; usz[1] = 16u;
+            lw2[0] = 4; lw2[1] = 2;
+            lh2[0] = 4; lh2[1] = 2;
+            CHECK(TP_OK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0u, obuf,
+                                             sizeof(obuf), &wrote)),
+                  "compat: _ex writes the reference file");
+            CHECK(TP_OK(tp_ktx2_write_uni(ulev, usz, lw2, lh2, 2, legacy,
+                                          sizeof(legacy), &wrote_legacy)),
+                  "compat: the pre-flags tp_ktx2_write_uni still works");
+            CHECK(wrote_legacy == wrote && memcmp(legacy, obuf, wrote) == 0,
+                  "compat: the old signature produces the identical file");
+            /* And it validates: the shim goes through the same tp_uni_check. */
+            usz[1] = 32u;
+            CHECK(tp_ktx2_write_uni(ulev, usz, lw2, lh2, 2, legacy,
+                                    sizeof(legacy),
+                                    &wrote_legacy) == TP_ERROR_INVALID_ARGUMENT,
+                  "compat: the old signature still rejects a bad level size");
+        }
     }
 
     free(dec);
@@ -1961,11 +1988,11 @@ static void test_ktx2_uni_zstd_write(void) {
             uint8_t *raw = (uint8_t *)malloc(raw_n);
             uint64_t prev_end = 0;
             CHECK(raw_n > 0, "uni size for a 3-level chain");
-            CHECK(TP_OK(tp_ktx2_write_uni(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
+            CHECK(TP_OK(tp_ktx2_write_uni_ex(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
                                           raw_n, NULL)),
                   "write 3-level uni ktx2 (scheme 0)");
             memset(raw, 0xAB, raw_n); /* poison: only what the writer writes may survive */
-            CHECK(TP_OK(tp_ktx2_write_uni(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
+            CHECK(TP_OK(tp_ktx2_write_uni_ex(mlev, msz, W, H, NL, TP_UNI_SRGB, raw,
                                           raw_n, NULL)),
                   "rewrite 3-level uni ktx2 over poison");
             prev_end = 80u + (uint64_t)NL * 24u + 44u; /* end of the DFD */

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1474,15 +1474,23 @@ static void test_ktx2_read_roundtrip(void) {
     {
         size_t usz = tc_uni_compressed_size(64, 64);
         uint8_t *uni = (uint8_t *)malloc(usz);
-        const uint8_t *levels[1]; size_t sizes[1]; uint32_t lw[1], lh[1];
+        const uint8_t *levels[1]; size_t sizes[1];
         uint8_t *ubuf = NULL; size_t ktx_size;
         CHECK(tc_uni_compress_rgba8(ref, 64, 64, (size_t)64 * 4u, uni, usz) == TC_SUCCESS,
               "uni compress");
-        levels[0] = uni; sizes[0] = usz; lw[0] = 64; lh[0] = 64;
+        levels[0] = uni; sizes[0] = usz;
         ktx_size = tp_ktx2_uni_size(sizes, 1);
         ubuf = (uint8_t *)malloc(ktx_size);
-        CHECK(TP_OK(tp_ktx2_write_uni(levels, sizes, lw, lh, 1, ubuf, ktx_size, NULL)),
+        CHECK(TP_OK(tp_ktx2_write_uni(levels, sizes, 64, 64, 1, TP_UNI_SRGB,
+                                      ubuf, ktx_size, NULL)),
               "write uni ktx2");
+        /* The DFD must carry the flags the caller asked for: sRGB transfer (2),
+         * and channelType RGB (0) since TP_UNI_ALPHA was not passed. */
+        {
+            size_t dfd = rd_u32(ubuf + 48);
+            CHECK(ubuf[dfd + 14] == 2u, "uni DFD transfer = sRGB");
+            CHECK(ubuf[dfd + 31] == 0u, "uni DFD channelType = RGB");
+        }
         CHECK(TP_OK(tp_ktx2_read(ubuf, ktx_size, &img)), "read uni ktx2");
         CHECK(img.is_uni && img.vk_format == 0u, "uni marker");
         CHECK(img.width == 64 && img.num_levels == 1, "uni header");
@@ -1566,16 +1574,29 @@ static void test_ktx2_read_roundtrip(void) {
     {
         const uint8_t *ulev[2];
         size_t usz[2];
-        uint32_t uw[2], uh[2];
         uint8_t dummy[16];
         size_t wrote = 0;
         ulev[0] = dummy; ulev[1] = dummy;
         usz[0] = (size_t)-1 - 64u; usz[1] = 1024u; /* cursor + sizes[0] wraps */
-        uw[0] = 4; uh[0] = 4; uw[1] = 2; uh[1] = 2;
         CHECK(tp_ktx2_uni_size(usz, 2) == 0, "uni layout overflow -> size 0");
-        CHECK(tp_ktx2_write_uni(ulev, usz, uw, uh, 2, dummy, sizeof(dummy),
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, dummy, sizeof(dummy),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "reject uni write with overflowing level sizes");
+
+        /* The scheme-0 writer now enforces the same rules as the Zstd one: each
+         * of these emits a file tp_ktx2_read would refuse, so the write must
+         * fail rather than hand back an unloadable asset. */
+        usz[0] = 16u; usz[1] = 16u; /* 4x4 and 2x2 are one block each */
+        CHECK(tp_ktx2_write_uni(ulev, usz, 131072, 4, 2, 0u, dummy, sizeof(dummy),
+                                &wrote) == TP_ERROR_INVALID_ARGUMENT,
+              "write_uni rejects a dimension over TP_KTX2_MAX_DIM");
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0x4u, dummy, sizeof(dummy),
+                                &wrote) == TP_ERROR_INVALID_ARGUMENT,
+              "write_uni rejects an unknown flag bit");
+        usz[1] = 32u; /* level 1 of a 4x4 base is 2x2 = one block = 16 B */
+        CHECK(tp_ktx2_write_uni(ulev, usz, 4, 4, 2, 0u, dummy, sizeof(dummy),
+                                &wrote) == TP_ERROR_INVALID_ARGUMENT,
+              "write_uni rejects a level size that mismatches the dimensions");
     }
 
     free(dec);
@@ -1619,7 +1640,6 @@ static void test_ktx2_uni_zstd_write(void) {
      * than quietly staying in bounds. */
     const uint8_t *levels[TP_KTX2_MAX_LEVELS];
     size_t sizes[TP_KTX2_MAX_LEVELS], usz, ktx_n = 0;
-    uint32_t lw[TP_KTX2_MAX_LEVELS], lh[TP_KTX2_MAX_LEVELS];
     tp_ktx2_image img;
     const size_t npix = (size_t)W * H;
     int i;
@@ -1629,11 +1649,12 @@ static void test_ktx2_uni_zstd_write(void) {
     CHECK(tc_uni_compress_rgba8(ref, W, H, (size_t)W * 4u, uni, usz) == TC_SUCCESS,
           "uni compress");
     for (i = 0; i < TP_KTX2_MAX_LEVELS; ++i) {
-        levels[i] = uni; sizes[i] = usz; lw[i] = W; lh[i] = H;
+        levels[i] = uni; sizes[i] = usz;
     }
 
     CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
-                                       NULL, levels, sizes, lw, lh, 1, &ktx,
+                                       NULL, levels, sizes, W, H, 1,
+                                       TP_UNI_SRGB | TP_UNI_ALPHA, &ktx,
                                        &ktx_n)),
           "write uni zstd ktx2");
     CHECK(ktx != NULL && ktx_n > 0, "zstd ktx2 produced");
@@ -1686,30 +1707,58 @@ static void test_ktx2_uni_zstd_write(void) {
         for (i = 0; i < sizeof(bad_in) / sizeof(bad_in[0]); ++i) {
             uint8_t *bad = (uint8_t *)0x1; /* must be overwritten with NULL */
             size_t bad_n = 123u;
-            sizes[0] = bad_in[i].sz; lw[0] = bad_in[i].w; lh[0] = bad_in[i].h;
+            sizes[0] = bad_in[i].sz;
             CHECK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
                                          passthrough_zenc, NULL, levels, sizes,
-                                         lw, lh, bad_in[i].n, &bad,
+                                         bad_in[i].w, bad_in[i].h, bad_in[i].n,
+                                         0u, &bad,
                                          &bad_n) == TP_ERROR_INVALID_ARGUMENT,
                   bad_in[i].what);
             CHECK(bad == NULL && bad_n == 0u, "outputs cleared on failure");
         }
-        sizes[0] = usz; lw[0] = W; lh[0] = H;
+        sizes[0] = usz;
     }
 
-    /* KTX2 >= 2.0.4: a supercompressed file keeps the real pre-deflation
-     * bytesPlane0 (the old "must be 0" rule is retired), so the DFD the writer
-     * emits must still say 16 even under scheme 2. */
+    /* The DFD must describe what the caller actually encoded. Neither fact is
+     * recoverable from the block bytes, and a consumer that honours the DFD
+     * (libktx, glTF KHR_texture_basisu) decodes sRGB and picks an alpha-capable
+     * transcode target from exactly these two fields. */
     {
         uint8_t *k2 = NULL;
-        size_t k2n = 0, dfd_off;
+        size_t k2n = 0, dfd;
+        /* sRGB + alpha: BT709 primaries are the pairing the glTF profile wants. */
         CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
                                            passthrough_zenc, NULL, levels, sizes,
-                                           lw, lh, 1, &k2, &k2n)),
-              "rewrite for DFD check");
-        dfd_off = rd_u32(k2 + 48);
-        CHECK(k2[dfd_off + 20] == 16u, "DFD bytesPlane0 = 16 under scheme 2");
+                                           W, H, 1, TP_UNI_SRGB | TP_UNI_ALPHA,
+                                           &k2, &k2n)),
+              "write uni zstd (srgb + alpha)");
+        dfd = rd_u32(k2 + 48);
+        /* KTX2 >= 2.0.4 keeps the real pre-deflation bytesPlane0 even when
+         * supercompressed; the old "must be 0" rule is retired. */
+        CHECK(k2[dfd + 20] == 16u, "DFD bytesPlane0 = 16 under scheme 2");
+        CHECK(k2[dfd + 12] == 166u, "DFD colorModel = UASTC");
+        CHECK(k2[dfd + 13] == 1u, "DFD primaries = BT709 (sRGB)");
+        CHECK(k2[dfd + 14] == 2u, "DFD transfer = sRGB");
+        CHECK(k2[dfd + 31] == 3u, "DFD channelType = UASTC_RGBA");
         tp_free(NULL, k2);
+
+        /* Linear + no alpha: the glTF profile pairs linear with UNSPECIFIED
+         * primaries, and an alpha-less payload must not claim RGBA. */
+        CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
+                                           passthrough_zenc, NULL, levels, sizes,
+                                           W, H, 1, 0u, &k2, &k2n)),
+              "write uni zstd (linear, no alpha)");
+        dfd = rd_u32(k2 + 48);
+        CHECK(k2[dfd + 13] == 0u, "DFD primaries = UNSPECIFIED (linear)");
+        CHECK(k2[dfd + 14] == 1u, "DFD transfer = linear");
+        CHECK(k2[dfd + 31] == 0u, "DFD channelType = UASTC_RGB");
+        tp_free(NULL, k2);
+
+        /* An unknown flag bit is a caller bug, not something to silently drop. */
+        CHECK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound, passthrough_zenc,
+                                     NULL, levels, sizes, W, H, 1, 0x8u, &k2,
+                                     &k2n) == TP_ERROR_INVALID_ARGUMENT,
+              "reject an unknown uni flag bit");
     }
 
     free(dec);

--- a/tools/texpipe/test/test_texpipe.c
+++ b/tools/texpipe/test/test_texpipe.c
@@ -1550,7 +1550,7 @@ static void test_ktx2_read_roundtrip(void) {
     CHECK(p >= 30.0, "astc ktx2 decode PSNR >= 30 dB");
     tp_free(NULL, ktx); ktx = NULL;
 
-    /* --- uni (UASTC) KTX2: write_uni -> read -> decode + transcode --- */
+    /* --- private uni KTX2: write_uni -> read -> decode + transcode --- */
     {
         size_t usz = tc_uni_compressed_size(64, 64);
         uint8_t *uni = (uint8_t *)malloc(usz);
@@ -1568,6 +1568,8 @@ static void test_ktx2_read_roundtrip(void) {
          * and channelType RGB (0) since TP_UNI_ALPHA was not passed. */
         {
             size_t dfd = rd_u32(ubuf + 48);
+            CHECK(ubuf[dfd + 12] == 0u,
+                  "private uni DFD does not claim Basis UASTC");
             CHECK(ubuf[dfd + 14] == 2u, "uni DFD transfer = sRGB");
             CHECK(ubuf[dfd + 31] == 0u, "uni DFD channelType = RGB");
         }
@@ -1578,6 +1580,15 @@ static void test_ktx2_read_roundtrip(void) {
         p = psnr_rgba(ref, dec, npix);
         printf("    uni ktx2 read+decode level0 PSNR=%.2f dB\n", p);
         CHECK(p >= 25.0, "uni ktx2 decode PSNR >= 25 dB");
+        {
+            size_t dfd = rd_u32(ubuf + 48);
+            ubuf[dfd + 12] = 166u;
+            CHECK(tp_ktx2_read(ubuf, ktx_size, &img) == TP_ERROR_UNSUPPORTED,
+                  "Basis UASTC is not mistaken for private uni");
+            ubuf[dfd + 12] = 0u;
+            CHECK(TP_OK(tp_ktx2_read(ubuf, ktx_size, &img)),
+                  "restore private uni parse after rejection check");
+        }
         /* transcode uni -> BC7, decode, and confirm it survives the transcode */
         {
             size_t bsz = tc_bc7_compressed_size(64, 64);
@@ -1591,6 +1602,31 @@ static void test_ktx2_read_roundtrip(void) {
             CHECK(p >= 25.0, "uni->bc7 PSNR >= 25 dB");
             free(bc7);
         }
+
+        /* The same uni bytes are valid standard ASTC 4x4 blocks. This mode is
+         * the interoperable KTX2 carrier: it must not advertise private uni or
+         * Basis UASTC semantics. */
+        CHECK(TP_OK(tp_ktx2_write_uni_ex(
+                  levels, sizes, 64, 64, 1,
+                  TP_UNI_SRGB | TP_UNI_ALPHA | TP_UNI_ASTC_KTX2, ubuf,
+                  ktx_size, NULL)),
+              "write uni bytes as standard ASTC ktx2");
+        {
+            size_t dfd = rd_u32(ubuf + 48);
+            CHECK(rd_u32(ubuf + 12) == 158u,
+                  "ASTC carrier vkFormat = ASTC_4x4_SRGB_BLOCK");
+            CHECK(ubuf[dfd + 12] == 162u, "ASTC carrier DFD colorModel = ASTC");
+            CHECK(ubuf[dfd + 14] == 2u, "ASTC carrier DFD transfer = sRGB");
+        }
+        CHECK(TP_OK(tp_ktx2_read(ubuf, ktx_size, &img)),
+              "read standard ASTC carrier");
+        CHECK(!img.is_uni && img.codec == TP_CODEC_ASTC && img.srgb,
+              "ASTC carrier is parsed as standard ASTC");
+        CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, 0, dec, npix * 4u)),
+              "decode standard ASTC carrier");
+        p = psnr_rgba(ref, dec, npix);
+        printf("    uni bytes -> ASTC KTX2 -> decode PSNR=%.2f dB\n", p);
+        CHECK(p >= 25.0, "ASTC carrier decode PSNR >= 25 dB");
         free(ubuf); free(uni);
     }
 
@@ -1683,7 +1719,7 @@ static void test_ktx2_read_roundtrip(void) {
         CHECK(tp_ktx2_write_uni_ex(ulev, usz, 131072, 4, 2, 0u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects a dimension over TP_KTX2_MAX_DIM");
-        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0x4u, obuf, sizeof(obuf),
+        CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 2, 0x8u, obuf, sizeof(obuf),
                                 &wrote) == TP_ERROR_INVALID_ARGUMENT,
               "write_uni rejects an unknown flag bit");
         CHECK(tp_ktx2_write_uni_ex(ulev, usz, 4, 4, 8, 0u, obuf, sizeof(obuf),
@@ -1847,14 +1883,12 @@ static void test_ktx2_uni_zstd_write(void) {
         sizes[0] = usz;
     }
 
-    /* The DFD must describe what the caller actually encoded. Neither fact is
-     * recoverable from the block bytes, and a consumer that honours the DFD
-     * (libktx, glTF KHR_texture_basisu) decodes sRGB and picks an alpha-capable
-     * transcode target from exactly these two fields. */
+    /* The private DFD must describe what the caller actually encoded without
+     * falsely claiming the Basis UASTC color model. */
     {
         uint8_t *k2 = NULL;
         size_t k2n = 0, dfd;
-        /* sRGB + alpha: BT709 primaries are the pairing the glTF profile wants. */
+        /* sRGB + alpha. */
         CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
                                            passthrough_zenc, NULL, levels, sizes,
                                            W, H, 1, TP_UNI_SRGB | TP_UNI_ALPHA,
@@ -1864,10 +1898,10 @@ static void test_ktx2_uni_zstd_write(void) {
         /* KTX2 >= 2.0.4 keeps the real pre-deflation bytesPlane0 even when
          * supercompressed; the old "must be 0" rule is retired. */
         CHECK(k2[dfd + 20] == 16u, "DFD bytesPlane0 = 16 under scheme 2");
-        CHECK(k2[dfd + 12] == 166u, "DFD colorModel = UASTC");
+        CHECK(k2[dfd + 12] == 0u, "private DFD colorModel = UNSPECIFIED");
         CHECK(k2[dfd + 13] == 1u, "DFD primaries = BT709 (sRGB)");
         CHECK(k2[dfd + 14] == 2u, "DFD transfer = sRGB");
-        CHECK(k2[dfd + 31] == 3u, "DFD channelType = UASTC_RGBA");
+        CHECK(k2[dfd + 31] == 3u, "private DFD channelType = RGBA");
         /* The flags must survive the round trip: a uni file has no vkFormat, so
          * if the reader does not parse the DFD the caller cannot tell sRGB from
          * linear or RGBA from RGB, and the flags buy nothing. */
@@ -1878,8 +1912,7 @@ static void test_ktx2_uni_zstd_write(void) {
         tp_ktx2_image_free(NULL, &img);
         tp_free(NULL, k2);
 
-        /* Linear + no alpha: the glTF profile pairs linear with UNSPECIFIED
-         * primaries, and an alpha-less payload must not claim RGBA. */
+        /* Linear + no alpha. */
         CHECK(TP_OK(tp_ktx2_write_uni_zstd(NULL, passthrough_zbound,
                                            passthrough_zenc, NULL, levels, sizes,
                                            W, H, 1, 0u, &k2, &k2n)),
@@ -1887,12 +1920,38 @@ static void test_ktx2_uni_zstd_write(void) {
         dfd = rd_u32(k2 + 48);
         CHECK(k2[dfd + 13] == 0u, "DFD primaries = UNSPECIFIED (linear)");
         CHECK(k2[dfd + 14] == 1u, "DFD transfer = linear");
-        CHECK(k2[dfd + 31] == 0u, "DFD channelType = UASTC_RGB");
+        CHECK(k2[dfd + 31] == 0u, "private DFD channelType = RGB");
         CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
                                       &img)),
               "read back linear uni");
         CHECK(img.srgb == 0 && img.has_alpha == 0,
               "reader recovers linear + no alpha");
+        tp_ktx2_image_free(NULL, &img);
+        tp_free(NULL, k2);
+
+        /* Standard scheme-2 ASTC carrier: unlike the default private wrapper,
+         * this is safe to hand to external KTX2 consumers. */
+        CHECK(TP_OK(tp_ktx2_write_uni_zstd(
+                  NULL, passthrough_zbound, passthrough_zenc, NULL, levels,
+                  sizes, W, H, 1,
+                  TP_UNI_SRGB | TP_UNI_ALPHA | TP_UNI_ASTC_KTX2, &k2, &k2n)),
+              "write uni zstd as standard ASTC");
+        dfd = rd_u32(k2 + 48);
+        CHECK(rd_u32(k2 + 12) == 158u,
+              "zstd ASTC carrier vkFormat = ASTC_4x4_SRGB_BLOCK");
+        CHECK(k2[dfd + 12] == 162u, "zstd ASTC carrier DFD colorModel = ASTC");
+        CHECK(TP_OK(tp_ktx2_read_zstd(k2, k2n, NULL, passthrough_zdec, NULL,
+                                      &img)),
+              "read back zstd ASTC carrier");
+        CHECK(!img.is_uni && img.codec == TP_CODEC_ASTC && img.srgb,
+              "zstd ASTC carrier parsed as standard ASTC");
+        CHECK(TP_OK(tp_ktx2_decode_level_rgba8(&img, 0, dec, npix * 4u)),
+              "decode zstd ASTC carrier");
+        {
+            double p = psnr_rgba(ref, dec, npix);
+            printf("    uni->zstd-ASTC-KTX2->decode PSNR=%.2f dB\n", p);
+            CHECK(p >= 30.0, "zstd ASTC carrier decode PSNR >= 30 dB");
+        }
         tp_ktx2_image_free(NULL, &img);
         tp_free(NULL, k2);
 

--- a/tools/texpipe/test/three_ktx2_loader/.gitignore
+++ b/tools/texpipe/test/three_ktx2_loader/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tools/texpipe/test/three_ktx2_loader/README.md
+++ b/tools/texpipe/test/three_ktx2_loader/README.md
@@ -1,0 +1,38 @@
+# Three.js KTX2Loader interoperability test
+
+This optional standalone test validates texpipe with an independent consumer:
+
+1. `generate_fixture.c` encodes an 8×8 RGBA image to texcomp `uni` blocks and
+   writes them using the standard ASTC 4×4 KTX2 carrier selected by
+   `TP_UNI_ASTC_KTX2`, with Zstd supercompression (scheme 2).
+2. `test.mjs` starts a loopback-only static server, launches Chrome through
+   Puppeteer, and loads that file with Three.js `KTX2Loader`.
+3. The test checks the compressed texture dimensions, mip count, byte length,
+   and sRGB DFD result, then renders it and verifies that the decoded red/green
+   gradients survive the independent decode and GPU upload.
+
+The explicit ASTC carrier matters: texcomp's private `uni` representation is
+made of valid ASTC blocks, but is not Basis UASTC wire data and must not be
+labelled or consumed as such.
+
+Install the browser dependencies once, then run the Make target from the
+repository root:
+
+```sh
+cd tools/texpipe/test/three_ktx2_loader
+npm install
+cd ../../../..
+make texpipe-three-ktx2-test
+```
+
+To reuse an existing dependency installation, point the test at a directory
+containing `package.json` and `node_modules/{three,puppeteer}`:
+
+```sh
+THREE_KTX2_NODE_ROOT=/path/to/web-project \
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome \
+  make texpipe-three-ktx2-test
+```
+
+The test is deliberately not part of `make tools-test`: the latter remains a
+self-contained pure-C gate without Node, npm, or browser requirements.

--- a/tools/texpipe/test/three_ktx2_loader/generate_fixture.c
+++ b/tools/texpipe/test/three_ktx2_loader/generate_fixture.c
@@ -1,0 +1,94 @@
+/*
+ * TinyEXR texpipe - Three.js KTX2Loader interoperability fixture generator.
+ *
+ * Copyright (c) 2014-2026 Syoyo Fujita and TinyEXR authors
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "texcomp.h"
+#include "texpipe.h"
+#include "tinyexr_zstd.h"
+
+static size_t zstd_bound(void *user, size_t src_size) {
+    (void)user;
+    return tinyexr_zstd_compress_bound(src_size);
+}
+
+static size_t zstd_compress(void *user, uint8_t *dst, size_t dst_cap,
+                            const uint8_t *src, size_t src_size) {
+    size_t result;
+    (void)user;
+    result = tinyexr_zstd_compress(dst, dst_cap, src, src_size, 3);
+    return tinyexr_zstd_is_error(result) ? 0u : result;
+}
+
+int main(int argc, char **argv) {
+    enum { WIDTH = 8, HEIGHT = 8 };
+    uint8_t rgba[WIDTH * HEIGHT * 4];
+    size_t uni_size = tc_uni_compressed_size(WIDTH, HEIGHT);
+    uint8_t *uni = NULL;
+    const uint8_t *levels[1];
+    size_t level_sizes[1];
+    uint8_t *ktx2 = NULL;
+    size_t ktx2_size = 0;
+    FILE *file = NULL;
+    int x, y;
+    int status = 1;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s output.ktx2\n", argv[0]);
+        return 2;
+    }
+
+    uni = (uint8_t *)malloc(uni_size);
+    if (!uni) goto cleanup;
+    for (y = 0; y < HEIGHT; ++y) {
+        for (x = 0; x < WIDTH; ++x) {
+            size_t offset = ((size_t)y * WIDTH + (size_t)x) * 4u;
+            rgba[offset + 0] = (uint8_t)(x * 255 / (WIDTH - 1));
+            rgba[offset + 1] = (uint8_t)(y * 255 / (HEIGHT - 1));
+            rgba[offset + 2] = 64u;
+            rgba[offset + 3] =
+                (uint8_t)((x + y) * 255 / (WIDTH + HEIGHT - 2));
+        }
+    }
+    if (tc_uni_compress_rgba8(rgba, WIDTH, HEIGHT, WIDTH * 4u, uni,
+                              uni_size) != TC_SUCCESS)
+        goto cleanup;
+
+    levels[0] = uni;
+    level_sizes[0] = uni_size;
+    if (tp_ktx2_write_uni_zstd(NULL, zstd_bound, zstd_compress, NULL, levels,
+                               level_sizes, WIDTH, HEIGHT, 1,
+                               TP_UNI_SRGB | TP_UNI_ALPHA |
+                                   TP_UNI_ASTC_KTX2,
+                               &ktx2,
+                               &ktx2_size) != TP_SUCCESS)
+        goto cleanup;
+
+    file = fopen(argv[1], "wb");
+    if (!file) goto cleanup;
+    if (fwrite(ktx2, 1, ktx2_size, file) != ktx2_size) {
+        fclose(file);
+        file = NULL;
+        goto cleanup;
+    }
+    if (fclose(file) != 0) {
+        file = NULL;
+        goto cleanup;
+    }
+    file = NULL;
+    printf("three-ktx2: wrote %zu-byte 8x8 scheme-2 ASTC fixture\n",
+           ktx2_size);
+    status = 0;
+
+cleanup:
+    if (file) fclose(file);
+    tp_free(NULL, ktx2);
+    free(uni);
+    return status;
+}

--- a/tools/texpipe/test/three_ktx2_loader/package.json
+++ b/tools/texpipe/test/three_ktx2_loader/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tinyexr-three-ktx2-loader-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test.mjs ../../../../build/texpipe/three-ktx2.ktx2"
+  },
+  "devDependencies": {
+    "puppeteer": "^24.25.0",
+    "three": ">=0.177.0"
+  }
+}

--- a/tools/texpipe/test/three_ktx2_loader/test.mjs
+++ b/tools/texpipe/test/three_ktx2_loader/test.mjs
@@ -1,0 +1,170 @@
+/*
+ * TinyEXR texpipe - standalone Three.js KTX2Loader interoperability test.
+ *
+ * Copyright (c) 2014-2026 Syoyo Fujita and TinyEXR authors
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.resolve(process.argv[2] || 'build/texpipe/three-ktx2.ktx2');
+const dependencyRoot = path.resolve(
+  process.env.THREE_KTX2_NODE_ROOT || TEST_DIR);
+const nodeModules = path.join(dependencyRoot, 'node_modules');
+const require = createRequire(path.join(dependencyRoot, 'package.json'));
+
+function fail(message) {
+  throw new Error(`three-ktx2: ${message}`);
+}
+
+if (!fs.existsSync(fixture)) fail(`fixture not found: ${fixture}`);
+if (!fs.existsSync(path.join(nodeModules, 'three/build/three.module.js'))) {
+  fail(`Three.js not found under ${nodeModules}; run npm install in ${TEST_DIR} ` +
+    'or set THREE_KTX2_NODE_ROOT');
+}
+
+let puppeteer;
+try {
+  puppeteer = require('puppeteer');
+} catch (error) {
+  fail(`Puppeteer not found under ${nodeModules}: ${error.message}`);
+}
+
+const html = `<!doctype html>
+<meta charset="utf-8">
+<canvas id="canvas" width="8" height="8"></canvas>
+<script type="importmap">
+{"imports":{"three":"/node_modules/three/build/three.module.js",
+"three/addons/":"/node_modules/three/examples/jsm/"}}
+</script>
+<script type="module">
+import * as THREE from 'three';
+import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+
+try {
+  const renderer = new THREE.WebGLRenderer({canvas: document.querySelector('#canvas')});
+  const loader = new KTX2Loader()
+    .setTranscoderPath('/node_modules/three/examples/jsm/libs/basis/')
+    .detectSupport(renderer);
+  const texture = await loader.loadAsync('/fixture.ktx2');
+  const mip = texture.mipmaps[0];
+  const scene = new THREE.Scene();
+  const material = new THREE.MeshBasicMaterial({map: texture});
+  const quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
+  scene.add(quad);
+  const target = new THREE.WebGLRenderTarget(8, 8);
+  const pixels = new Uint8Array(8 * 8 * 4);
+  renderer.setRenderTarget(target);
+  renderer.render(scene, new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1));
+  renderer.readRenderTargetPixels(target, 0, 0, 8, 8, pixels);
+  let redMin = 255, redMax = 0, greenMin = 255, greenMax = 0;
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    redMin = Math.min(redMin, pixels[offset]);
+    redMax = Math.max(redMax, pixels[offset]);
+    greenMin = Math.min(greenMin, pixels[offset + 1]);
+    greenMax = Math.max(greenMax, pixels[offset + 1]);
+  }
+  window.__threeKTX2Result = {
+    compressed: texture.isCompressedTexture === true,
+    width: texture.image.width,
+    height: texture.image.height,
+    mipLevels: texture.mipmaps.length,
+    byteLength: mip.data.byteLength,
+    colorSpace: texture.colorSpace,
+    format: texture.format,
+    redRange: redMax - redMin,
+    greenRange: greenMax - greenMin
+  };
+  target.dispose();
+  quad.geometry.dispose();
+  material.dispose();
+  loader.dispose();
+  renderer.dispose();
+} catch (error) {
+  window.__threeKTX2Error = error?.stack || error?.message || String(error);
+}
+</script>`;
+
+const mime = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.wasm', 'application/wasm'],
+  ['.ktx2', 'image/ktx2']
+]);
+
+function sendFile(response, filename) {
+  response.writeHead(200, {
+    'Content-Type': mime.get(path.extname(filename)) || 'application/octet-stream'
+  });
+  fs.createReadStream(filename).pipe(response);
+}
+
+const server = http.createServer((request, response) => {
+  const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+  if (pathname === '/') {
+    response.writeHead(200, {'Content-Type': mime.get('.html')});
+    response.end(html);
+    return;
+  }
+  if (pathname === '/fixture.ktx2') {
+    sendFile(response, fixture);
+    return;
+  }
+  if (pathname.startsWith('/node_modules/')) {
+    const relative = pathname.slice('/node_modules/'.length);
+    const filename = path.resolve(nodeModules, relative);
+    const root = `${path.resolve(nodeModules)}${path.sep}`;
+    if (filename.startsWith(root) && fs.statSync(filename, {throwIfNoEntry: false})?.isFile()) {
+      sendFile(response, filename);
+      return;
+    }
+  }
+  response.writeHead(404);
+  response.end('not found');
+});
+
+let browser;
+try {
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  const launch = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+      '--use-angle=swiftshader', '--enable-unsafe-swiftshader']
+  };
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    launch.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  browser = await puppeteer.launch(launch);
+  const page = await browser.newPage();
+  await page.goto(`http://127.0.0.1:${address.port}/`, {waitUntil: 'load'});
+  await page.waitForFunction(
+    () => window.__threeKTX2Result || window.__threeKTX2Error,
+    {timeout: 60000});
+  const state = await page.evaluate(() => ({
+    result: window.__threeKTX2Result,
+    error: window.__threeKTX2Error
+  }));
+  if (state.error) fail(`KTX2Loader failed: ${state.error}`);
+  const result = state.result;
+  if (!result?.compressed || result.width !== 8 || result.height !== 8 ||
+      result.mipLevels !== 1 || result.byteLength !== 64 ||
+      result.colorSpace !== 'srgb' || result.redRange < 100 ||
+      result.greenRange < 100) {
+    fail(`unexpected texture: ${JSON.stringify(result)}`);
+  }
+  console.log(`three-ktx2: PASS ${JSON.stringify(result)}`);
+} finally {
+  await browser?.close().catch(() => {});
+  await new Promise((resolve) => server.close(resolve));
+}


### PR DESCRIPTION
The read side already supported supercompressionScheme 2 (`tp_ktx2_read_zstd`), but nothing could produce such a stream, so uni KTX2 could only be written raw — typically several times larger on disk than the form real KTX2/UASTC assets ship in.

`tp_ktx2_write_uni_zstd` mirrors the reader: the host supplies `zbound`/`zenc` callbacks (wrapping `ZSTD_compressBound` / `ZSTD_compress`), so the library keeps its zero-dependency property. Each level is compressed independently, so a reader can inflate them one at a time. The compressed size isn't known up front, so the output is allocated with the `tir_allocator` and returned (free with `tp_free`) rather than written into a caller buffer.

Reviewing that writer turned up a set of bugs in the surrounding KTX2 code, so the PR grew past its title. What's here now:

## The writer

- `tp_ktx2_write_uni_zstd`, scheme 2, via host zstd callbacks.
- Levels are compressed straight into the output buffer at a running cursor, then copied down into an exact-sized one. Two allocations instead of `num_levels + 1`, and no worst-case block left alive for a file that is typically a fraction of it — this matters on the 32-bit wasm heap.

## Correctness fixes in existing code

**Heap buffer overflow in `tp_write_ktx2_array`.** The file is sized from `layers[0]`, but the payload loop copies each layer's *own* block sizes, and the only cross-layer check was `num_levels`/`num_faces`/`codec`. A 65×65 layer beside a 64×64 one agrees on all three — both have a 7-level pyramid — while its level-0 blocks are 4624 bytes against 4096, so it memcpy'd off the end of the caller's buffer. Reproduced under ASan (`heap-buffer-overflow ... WRITE of size 4624`) before fixing. Layers must now match block-for-block. The old array test could never have caught this: it assigns the same `tp_blocks` to every layer, so the sizes agreed trivially.

**The uni DFD described the wrong texture.** Transfer was hard-coded LINEAR and channelType hard-coded UASTC_RGB, regardless of what the caller encoded. Neither fact is recoverable from the block bytes, and both are what a DFD-honouring consumer keys off: sRGB albedo was declared linear-light, and an RGBA texture declared no alpha, which silently drops the alpha channel when transcoded to BC1/ETC1. Both uni writers now take `TP_UNI_SRGB` / `TP_UNI_ALPHA`. Values verified against Khronos `khr_df.h` rather than recall. Primaries now follow the transfer, because the glTF profile `ktx validate` enforces admits only BT709+sRGB or UNSPECIFIED+linear — we hard-coded BT709, so every *linear* uni file we wrote failed that profile.

**The flags were write-only.** A uni file has no `vkFormat`, so the DFD is the only place the sRGB and alpha facts live — and the reader never parsed it. The round trip now recovers them into `img.srgb` / `img.has_alpha` (new field).

**Writers could emit files the library itself refuses to load.** None of `tp_ktx2_write`, `tp_write_ktx2_array` or the uni writers bounded dimensions by `TP_KTX2_MAX_DIM`, layers by `TP_KTX2_MAX_LAYERS`, or levelCount by the pyramid the base dimensions actually have — all of which the reader enforces. A build-time success that fails at load time.

**Codec/format disagreement.** The payload comes from the blocks but the vkFormat and DFD come from the options; nothing checked they agreed, so a BC7 chain written with BC1 options produced a file whose header lies about its contents.

**NULL dereference on a zeroed `tp_blocks`** — what a failed `tp_compress_chain` leaves behind. `num_levels` was bounded only from above, then `blk[0]` was read.

**`size_t` overflow** in the level/layout/array size math (unchecked face sums, level accumulation, and the `num_layers` multiply). These wrap on the 32-bit wasm heap and under-report the very buffer the payload memcpy then overruns. The uni layout already guarded this; the older paths didn't.

**Reader lifetime bugs.** A failed read handed back a half-filled image whose level pointers aimed into a buffer it had just freed; that invariant now holds on every path. `tp_ktx2_image_free` left `levels[].data` dangling.

## API

`tp_ktx2_write_uni` keeps its exact signature — byte-for-byte what `release` declares — so existing callers compile untouched. The new `(base_w, base_h, flags)` form is `tp_ktx2_write_uni_ex`; the old one is a shim over it (it only ever read `level_w[0]`/`level_h[0]`, and `flags = 0` reproduces the DFD it always emitted). Not a fork: the shim goes through the same validation. New callers should prefer `_ex`, or their textures ship without their sRGB/alpha facts.

Added: `tp_ktx2_write_uni_ex`, `tp_ktx2_write_uni_zstd`, `TP_UNI_SRGB`/`TP_UNI_ALPHA`, `tp_ktx2_image::has_alpha`.

## Tests

Round-trips uni → zstd-KTX2 → `tp_ktx2_read_zstd` → decode, and checks scheme/vkFormat/uncompressedByteLength plus that plain `tp_ktx2_read` refuses the stream. Beyond that, the coverage that was missing and would have hidden these:

- A real 3-level mip chain, for both schemes. The original test wrote a *single* level — which exercises none of the new logic, since a reversed or off-by-one packing loop still round-trips with one level. Now asserts the level index is in-bounds, non-overlapping and exactly fills the file, and that every mip decodes to the right image at the right size.
- NPOT (65×33). Every level size is derived from the base dimensions, so a writer/reader rounding disagreement surfaces here and nowhere else.
- Layers with mismatched dimensions must be refused (this is the ASan repro above).
- The DFD flags must survive write → read.
- `mipPadding` is zero: the scheme-0 writer now zeroes only the alignment gaps, so the test writes over a poisoned buffer and checks nothing leaked through.
- The shrink-copy branch — the path every real zstd caller takes — is actually executed; the passthrough compressor used to make the compressed data exactly fill the buffer, so it never ran.
- The scheme-0 rejection asserts now pass an adequately sized output buffer, with a control proving a valid write succeeds into it. They previously passed a 16-byte buffer against a 208-byte file, so they fired on `out_size < need` and would have passed with the validation deleted.

Verified by exit code (`texpipe`, `texpipe-c11-gate`, `texcomp`, `envmap`, `texcomp-test`, `texpipe-test`), and `texpipe-test` is clean under `-fsanitize=address,undefined`.

## Notes for the reviewer

Two things left deliberately undone: `tp_write_ktx2_array` is still a near-copy of `tp_ktx2_write` (that duplication is precisely why the hardening kept landing in only one of them — worth unifying, but it's a refactor beyond this PR), and both still memset the whole output buffer before overwriting nearly all of it.

One spec point worth flagging, since it looks like a bug and isn't: the DFD keeps `bytesPlane0 = 16` under supercompression. KTX2 2.0.4 (2025-02-20, KTX-Specification#221) **removed** the old "bytesPlane must be 0 if supercompressed" rule and now requires the true pre-deflation value; current `ktx validate` warns on `bytesPlane0 == 0` as deprecated. There's a test pinning it so it doesn't get "corrected" back.
