### PR TITLE
Bound NONE-compression HALF scanline read against data_len (heap OOB read)

### DIFF
--- a/tinyexr.h
+++ b/tinyexr.h
@@ -5607,6 +5607,12 @@ static bool DecodePixelData(/* out */ unsigned char **out_images,
                   (size_t(height) - 1 - (size_t(y) + v)) * size_t(x_stride);
             }
 
+            if (reinterpret_cast<const unsigned char *>(line_ptr + width) >
+                (data_ptr + data_len)) {
+              // Insufficient data size (match the HALF->FLOAT / FLOAT->FLOAT / UINT->UINT branches)
+              return false;
+            }
+
             for (int u = 0; u < width; u++) {
               tinyexr::FP16 hf;
 


### PR DESCRIPTION
### Summary

Loading a crafted uncompressed (`compression = NONE`) HALF `.exr` through `LoadEXRImageFromMemory` / `LoadEXRImage` with native pixel types causes a heap out-of-bounds read. In `DecodePixelData`, the four HALF sub-branches decode a scanline; the HALF->FLOAT, FLOAT->FLOAT and UINT->UINT branches all bound the read against the chunk's declared `data_len`, but the HALF->HALF sub-branch does not.

### Root cause

```cpp
// HALF -> HALF: reads width half-words with NO data_len bound
for (int u = 0; u < width; u++) {
  tinyexr::FP16 hf;
  tinyexr::cpy2(&(hf.u), line_ptr + u);
  ...
}
// HALF -> FLOAT (sibling, a few lines below) HAS the guard:
if (reinterpret_cast<const unsigned char *>(line_ptr + width) > (data_ptr + data_len)) return false;
```

`width` comes from the header dataWindow; `line_ptr` points into the uncompressed scanline chunk whose length is the file-supplied `data_len` (only checked `!= 0` and `<= remaining_file_size`, never `>= width * pixel_data_size`). A chunk with a small `data_len` and a large `width` over-reads. (The `LoadEXR` RGBA convenience forces FLOAT and hits the guarded branch, so it is unaffected; the image API with native HALF reaches this.)

### Reproduction

A valid uncompressed single-channel HALF `.exr` (`width=1024, height=1`) built with `SaveEXRImageToMemory`, then the scanline chunk `dataSize` field overwritten from `2048` to `2` and the buffer truncated, loaded via `LoadEXRImageFromMemory` (native HALF) under AddressSanitizer:

```
AddressSanitizer: heap-buffer-overflow READ of size 1
  #0 tinyexr::cpy2            tinyexr.h:887
  #1 tinyexr::DecodePixelData tinyexr.h:5614
     tinyexr::DecodeEXRImage / LoadEXRImageFromMemory
```

The untampered file loads cleanly.

### Fix

Add the same guard the sibling branches use, before the HALF->HALF loop. Validated with AddressSanitizer: the crafted `.exr` is now rejected cleanly (returns an error, no OOB) and valid files still load. Found with a structure-aware model/asset parser fuzzer.
